### PR TITLE
fix(i18n): load the app store before reading the saved language

### DIFF
--- a/src/app-shell.startup.test.tsx
+++ b/src/app-shell.startup.test.tsx
@@ -198,6 +198,7 @@ function resolveStartupThreadComposerSelection(
 }
 
 vi.mock("./services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(
     (store: keyof typeof startupState.clientStore, key: string) => {
       return startupState.clientStore[store]?.[key];

--- a/src/app-shell/domains/useSelectedAgentSession.test.tsx
+++ b/src/app-shell/domains/useSelectedAgentSession.test.tsx
@@ -33,6 +33,7 @@ const {
 });
 
 vi.mock("../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync,
   writeClientStoreValue,
 }));

--- a/src/app-shell/domains/useSelectedComposerSession.test.tsx
+++ b/src/app-shell/domains/useSelectedComposerSession.test.tsx
@@ -47,6 +47,7 @@ const {
 });
 
 vi.mock("../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync,
   writeClientStoreValue,
 }));

--- a/src/app-shell/sections/useAppShellSearchRadarSection.test.tsx
+++ b/src/app-shell/sections/useAppShellSearchRadarSection.test.tsx
@@ -84,6 +84,7 @@ vi.mock("./useWorkspaceThreadListHydration", () => ({
 }));
 
 vi.mock("../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(() => null),
   writeClientStoreValue: vi.fn(),
 }));

--- a/src/app-shell/sections/useAppShellWorkspaceFlowsSection.test.tsx
+++ b/src/app-shell/sections/useAppShellWorkspaceFlowsSection.test.tsx
@@ -14,6 +14,7 @@ vi.mock("../../services/systemNotification", () => ({
 }));
 
 vi.mock("../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   writeClientStoreValue: vi.fn(),
 }));
 

--- a/src/features/app/components/OpenAppMenu.test.tsx
+++ b/src/features/app/components/OpenAppMenu.test.tsx
@@ -17,6 +17,7 @@ vi.mock("../../../services/toasts", () => ({
 }));
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   writeClientStoreValue: vi.fn(),
 }));
 

--- a/src/features/app/hooks/useSidebarMenus.test.tsx
+++ b/src/features/app/hooks/useSidebarMenus.test.tsx
@@ -132,6 +132,7 @@ vi.mock("../../../services/globalRuntimeNotices", () => ({
   pushGlobalRuntimeNotice: vi.fn(),
 }));
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: clientStoreMock.getClientStoreSync,
   writeClientStoreValue: clientStoreMock.writeClientStoreValue,
 }));

--- a/src/features/app/hooks/useSidebarSettingsPinnedActions.test.ts
+++ b/src/features/app/hooks/useSidebarSettingsPinnedActions.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../../../services/clientStorage";
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(),
   writeClientStoreValue: vi.fn(),
 }));

--- a/src/features/client-ui-visibility/hooks/useClientUiVisibility.test.tsx
+++ b/src/features/client-ui-visibility/hooks/useClientUiVisibility.test.tsx
@@ -12,6 +12,7 @@ import { useClientUiVisibility } from "./useClientUiVisibility";
 const clientStore = new Map<string, unknown>();
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn((store: string, key: string) =>
     clientStore.get(`${store}:${key}`),
   ),

--- a/src/features/engine/hooks/useEngineController.test.tsx
+++ b/src/features/engine/hooks/useEngineController.test.tsx
@@ -37,6 +37,7 @@ vi.mock("../../../services/tauri", () => ({
   switchEngine: vi.fn(),
 }));
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(),
   writeClientStoreValue: vi.fn(),
 }));

--- a/src/features/files/components/DetachedFileExplorerWindow.test.tsx
+++ b/src/features/files/components/DetachedFileExplorerWindow.test.tsx
@@ -104,6 +104,7 @@ vi.mock("../../../utils/platform", () => ({
 }));
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(() => "vscode"),
 }));
 

--- a/src/features/files/components/FileViewPanel.lazy-race.test.tsx
+++ b/src/features/files/components/FileViewPanel.lazy-race.test.tsx
@@ -38,6 +38,7 @@ vi.mock("../utils/codemirrorLanguageExtensions", () => ({
 }));
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(),
   writeClientStoreData: vi.fn(),
   writeClientStoreValue: vi.fn(),

--- a/src/features/files/components/FileViewPanel.typing-latency.test.tsx
+++ b/src/features/files/components/FileViewPanel.typing-latency.test.tsx
@@ -25,6 +25,7 @@ import {
 } from "../../../services/clientStorage";
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(),
   writeClientStoreData: vi.fn(),
   writeClientStoreValue: vi.fn(),

--- a/src/features/files/detachedFileExplorer.test.ts
+++ b/src/features/files/detachedFileExplorer.test.ts
@@ -25,6 +25,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 }));
 
 vi.mock("../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   writeClientStoreValue: (...args: any[]) => (writeClientStoreValueMock as any)(...args),
   getClientStoreSync: (...args: any[]) => (getClientStoreSyncMock as any)(...args),
 }));

--- a/src/features/git-history/components/GitHistoryPanel.test.tsx
+++ b/src/features/git-history/components/GitHistoryPanel.test.tsx
@@ -147,6 +147,7 @@ vi.mock("../../git/components/WorkspaceEditableDiffReviewSurface", () => ({
 }));
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(),
   writeClientStoreValue: vi.fn(),
 }));

--- a/src/features/kanban/utils/kanbanStorage.test.ts
+++ b/src/features/kanban/utils/kanbanStorage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(),
   writeClientStoreValue: vi.fn(),
 }));

--- a/src/features/layout/components/DesktopLayout.test.tsx
+++ b/src/features/layout/components/DesktopLayout.test.tsx
@@ -6,6 +6,7 @@ import { DesktopLayout } from "./DesktopLayout";
 import { useWorkspaceNoteCardsLayout } from "../../note-cards/components/WorkspaceNoteCardsLayoutContext";
 
 const clientStorageMock = vi.hoisted(() => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(),
   writeClientStoreValue: vi.fn(),
 }));

--- a/src/features/layout/hooks/useTransparencyPreference.test.tsx
+++ b/src/features/layout/hooks/useTransparencyPreference.test.tsx
@@ -29,6 +29,7 @@ clientStorageMock.writeClientStoreValue.mockImplementation(
 );
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: clientStorageMock.getClientStoreSync,
   writeClientStoreValue: clientStorageMock.writeClientStoreValue,
 }));

--- a/src/features/notifications/hooks/useGlobalRuntimeNoticeDock.test.tsx
+++ b/src/features/notifications/hooks/useGlobalRuntimeNoticeDock.test.tsx
@@ -34,6 +34,7 @@ function isReactActWarning(args: unknown[]): boolean {
 }
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: clientStorageMocks.getClientStoreSync,
   writeClientStoreValue: clientStorageMocks.writeClientStoreValue,
 }));

--- a/src/features/quick-switcher/hooks/useQuickSwitcherRecentFiles.test.tsx
+++ b/src/features/quick-switcher/hooks/useQuickSwitcherRecentFiles.test.tsx
@@ -10,6 +10,7 @@ const storageMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: storageMocks.getClientStoreSync,
   writeClientStoreValue: vi.fn(),
 }));

--- a/src/features/search/ranking/recentActions.test.ts
+++ b/src/features/search/ranking/recentActions.test.ts
@@ -6,6 +6,7 @@ const { getClientStoreSync, writeClientStoreValue } = vi.hoisted(() => ({
 }));
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync,
   writeClientStoreValue,
 }));

--- a/src/features/session-activity/hooks/useSessionRadarFeed.incremental.test.tsx
+++ b/src/features/session-activity/hooks/useSessionRadarFeed.incremental.test.tsx
@@ -12,6 +12,7 @@ import { useSessionRadarFeed } from "./useSessionRadarFeed";
 const clientStoreCache = new Map<string, unknown>();
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn((store: string, key: string) => clientStoreCache.get(`${store}:${key}`)),
   writeClientStoreValue: vi.fn((store: string, key: string, value: unknown) => {
     clientStoreCache.set(`${store}:${key}`, value);

--- a/src/features/session-activity/hooks/useSessionRadarFeed.parity.test.tsx
+++ b/src/features/session-activity/hooks/useSessionRadarFeed.parity.test.tsx
@@ -11,6 +11,7 @@ import { useSessionRadarFeed } from "./useSessionRadarFeed";
 const clientStoreCache = new Map<string, unknown>();
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn((store: string, key: string) => clientStoreCache.get(`${store}:${key}`)),
   writeClientStoreValue: vi.fn((store: string, key: string, value: unknown) => {
     clientStoreCache.set(`${store}:${key}`, value);

--- a/src/features/session-activity/hooks/useSessionRadarFeed.reconcile.test.tsx
+++ b/src/features/session-activity/hooks/useSessionRadarFeed.reconcile.test.tsx
@@ -14,6 +14,7 @@ import { useSessionRadarFeed } from "./useSessionRadarFeed";
 const clientStoreCache = new Map<string, unknown>();
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn((store: string, key: string) => clientStoreCache.get(`${store}:${key}`)),
   writeClientStoreValue: vi.fn((store: string, key: string, value: unknown) => {
     clientStoreCache.set(`${store}:${key}`, value);

--- a/src/features/session-activity/utils/sessionRadarHistoryManagement.writeOrder.test.ts
+++ b/src/features/session-activity/utils/sessionRadarHistoryManagement.writeOrder.test.ts
@@ -12,6 +12,7 @@ const clientStoreCache = new Map<string, unknown>();
 const writeOrder: string[] = [];
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn((store: string, key: string) => clientStoreCache.get(`${store}:${key}`)),
   writeClientStoreValue: vi.fn((store: string, key: string, value: unknown) => {
     clientStoreCache.set(`${store}:${key}`, value);

--- a/src/features/spec/components/spec-hub/reader/SpecHubSurfaceFrame.test.tsx
+++ b/src/features/spec/components/spec-hub/reader/SpecHubSurfaceFrame.test.tsx
@@ -24,6 +24,7 @@ vi.mock("react-i18next", () => ({
 }));
 
 vi.mock("../../../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: (_store: string, key: string) => layoutStore.get(key),
   writeClientStoreValue: (_store: string, key: string, value: unknown) => {
     layoutStore.set(key, value);

--- a/src/features/spec/detachedSpecHub.test.ts
+++ b/src/features/spec/detachedSpecHub.test.ts
@@ -24,6 +24,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 }));
 
 vi.mock("../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   writeClientStoreValue: (...args: any[]) => (writeClientStoreValueMock as any)(...args),
   getClientStoreSync: (...args: any[]) => (getClientStoreSyncMock as any)(...args),
 }));

--- a/src/features/spec/hooks/useSpecHub.test.tsx
+++ b/src/features/spec/hooks/useSpecHub.test.tsx
@@ -34,6 +34,7 @@ vi.mock("../../../lib/spec-core/runtime", () => ({
 }));
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(),
   writeClientStoreValue: vi.fn(),
 }));

--- a/src/features/subagent-ui/components/ConversationInspectorSplit.test.tsx
+++ b/src/features/subagent-ui/components/ConversationInspectorSplit.test.tsx
@@ -10,6 +10,7 @@ const getClientStoreSync = vi.fn();
 const writeClientStoreValue = vi.fn();
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: (...args: unknown[]) => getClientStoreSync(...args),
   writeClientStoreValue: (...args: unknown[]) =>
     writeClientStoreValue(...args),

--- a/src/features/tasks/utils/taskRunStorage.test.ts
+++ b/src/features/tasks/utils/taskRunStorage.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(),
   writeClientStoreValue: vi.fn(),
 }));

--- a/src/features/threads/hooks/useThreadMessaging.command-entrypoints.test.tsx
+++ b/src/features/threads/hooks/useThreadMessaging.command-entrypoints.test.tsx
@@ -50,6 +50,7 @@ vi.mock("../../../services/tauri", () => ({
 }));
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(),
   writeClientStoreValue: vi.fn(),
 }));

--- a/src/features/threads/hooks/useThreadMessaging.optimistic-render.test.tsx
+++ b/src/features/threads/hooks/useThreadMessaging.optimistic-render.test.tsx
@@ -49,6 +49,7 @@ vi.mock("../../../services/tauri", () => ({
 }));
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(),
   writeClientStoreValue: vi.fn(),
 }));

--- a/src/features/threads/hooks/useThreadMessaging.spec-root.test.tsx
+++ b/src/features/threads/hooks/useThreadMessaging.spec-root.test.tsx
@@ -47,6 +47,7 @@ vi.mock("../../../services/tauri", () => ({
 }));
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(),
   writeClientStoreValue: vi.fn(),
 }));

--- a/src/features/threads/hooks/useThreadMessaging.test-utils.tsx
+++ b/src/features/threads/hooks/useThreadMessaging.test-utils.tsx
@@ -63,6 +63,7 @@ vi.mock("../../../services/tauri", () => ({
 }));
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(),
   writeClientStoreValue: vi.fn(),
 }));

--- a/src/features/threads/hooks/useThreadsReducer.turn-final-meta.test.ts
+++ b/src/features/threads/hooks/useThreadsReducer.turn-final-meta.test.ts
@@ -8,6 +8,7 @@ const clientStorageMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: clientStorageMocks.getClientStoreSync,
   writeClientStoreValue: clientStorageMocks.writeClientStoreValue,
 }));

--- a/src/features/threads/utils/threadStorage.test.ts
+++ b/src/features/threads/utils/threadStorage.test.ts
@@ -6,6 +6,7 @@ const clientStorageMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: clientStorageMocks.getClientStoreSync,
   writeClientStoreValue: clientStorageMocks.writeClientStoreValue,
 }));

--- a/src/features/threads/utils/turnFinalMetaStorage.test.ts
+++ b/src/features/threads/utils/turnFinalMetaStorage.test.ts
@@ -7,6 +7,7 @@ const clientStorageMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: clientStorageMocks.getClientStoreSync,
   writeClientStoreValue: clientStorageMocks.writeClientStoreValue,
 }));

--- a/src/features/update/hooks/useReleaseNotes.test.ts
+++ b/src/features/update/hooks/useReleaseNotes.test.ts
@@ -13,6 +13,7 @@ vi.mock("@tauri-apps/api/app", () => ({
 }));
 
 vi.mock("../../../services/clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(),
   writeClientStoreValue: vi.fn(),
 }));

--- a/src/i18n/index.test.ts
+++ b/src/i18n/index.test.ts
@@ -1,10 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 let storedLanguage = "zh";
+let cachePopulated = false;
 const writeClientStoreValueMock = vi.hoisted(() => vi.fn());
+const loadClientStoreMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/clientStorage", () => ({
-  getClientStoreSync: vi.fn(() => storedLanguage),
+  // Only readable once loadClientStore "resolves" — mirrors the real bootstrap
+  // race: the sync cache is empty until the store finishes loading.
+  getClientStoreSync: vi.fn(() => (cachePopulated ? storedLanguage : undefined)),
+  loadClientStore: loadClientStoreMock,
   writeClientStoreValue: writeClientStoreValueMock,
 }));
 
@@ -12,7 +17,11 @@ describe("i18n dynamic locale loading", () => {
   beforeEach(() => {
     vi.resetModules();
     storedLanguage = "zh";
+    cachePopulated = false;
     writeClientStoreValueMock.mockReset();
+    loadClientStoreMock.mockReset().mockImplementation(async () => {
+      cachePopulated = true;
+    });
   });
 
   it("loads only the stored startup locale and loads another locale on switch", async () => {
@@ -32,6 +41,18 @@ describe("i18n dynamic locale loading", () => {
     expect(i18n.hasResourceBundle("en", "translation")).toBe(true);
     expect(i18n.t("files.loadingFiles")).not.toBe("files.loadingFiles");
     expect(i18n.t("settings.sidebarBasic")).not.toBe("settings.sidebarBasic");
+  });
+
+  it("awaits loadClientStore before reading the stored language (regression for #1085)", async () => {
+    // Without the await, getClientStoreSync would still see an empty cache
+    // here and fall back to the hardcoded default instead of the saved "en".
+    storedLanguage = "en";
+
+    const module = await import("./index");
+    const i18n = await module.i18nReady;
+
+    expect(loadClientStoreMock).toHaveBeenCalledWith("app");
+    expect(i18n.language).toBe("en");
   });
 
   it("loads a newly shipped translation bundle on switch", async () => {

--- a/src/i18n/index.test.ts
+++ b/src/i18n/index.test.ts
@@ -6,7 +6,7 @@ const writeClientStoreValueMock = vi.hoisted(() => vi.fn());
 const loadClientStoreMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/clientStorage", () => ({
-  // Only readable once loadClientStore "resolves" — mirrors the real bootstrap
+  // Only readable once loadClientStore "resolves", mirroring the real bootstrap
   // race: the sync cache is empty until the store finishes loading.
   getClientStoreSync: vi.fn(() => (cachePopulated ? storedLanguage : undefined)),
   loadClientStore: loadClientStoreMock,

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,6 +1,10 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
-import { getClientStoreSync, writeClientStoreValue } from "../services/clientStorage";
+import {
+  getClientStoreSync,
+  loadClientStore,
+  writeClientStoreValue,
+} from "../services/clientStorage";
 
 export type SupportedLanguage =
   | "zh"
@@ -155,6 +159,11 @@ i18nInstance.changeLanguage = (async (
 }) as typeof i18nInstance.changeLanguage;
 
 export const i18nReady = (async () => {
+  // Ensure the "app" store is in cache before we read the saved language —
+  // otherwise the sync read races the bootstrap preload and we'd fall back to
+  // the hardcoded default even when the user has an explicit choice saved.
+  // Fixes upstream #1085 (saved language reset on every restart).
+  await loadClientStore("app");
   const initialLanguage = await loadLanguageResource(getStoredLanguage());
   const resources = Object.entries(loadedResources).reduce<
     Record<string, { translation: Record<string, unknown> }>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -159,7 +159,7 @@ i18nInstance.changeLanguage = (async (
 }) as typeof i18nInstance.changeLanguage;
 
 export const i18nReady = (async () => {
-  // Ensure the "app" store is in cache before we read the saved language —
+  // Ensure the "app" store is in cache before we read the saved language,
   // otherwise the sync read races the bootstrap preload and we'd fall back to
   // the hardcoded default even when the user has an explicit choice saved.
   // Fixes upstream #1085 (saved language reset on every restart).

--- a/src/services/clientStorage.test.ts
+++ b/src/services/clientStorage.test.ts
@@ -138,6 +138,34 @@ describe("clientStorage", () => {
     });
   });
 
+  it("de-duplicates concurrent loadClientStore calls into a single read", async () => {
+    const invokeMock = vi.mocked(invoke);
+    const storage = await import("./clientStorage");
+    storage.resetClientStorageForTests();
+    invokeMock.mockImplementation(async (command, payload) => {
+      const args =
+        payload && typeof payload === "object" && !Array.isArray(payload)
+          ? (payload as Record<string, unknown>)
+          : null;
+      if (command === "client_store_read" && args?.store === "app") {
+        return { __schemaVersion: 1, language: "en" };
+      }
+      return null;
+    });
+
+    await Promise.all([
+      storage.loadClientStore("app"),
+      storage.loadClientStore("app"),
+    ]);
+
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(storage.getClientStoreSync("app", "language")).toBe("en");
+
+    await storage.loadClientStore("app");
+
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+  });
+
   it("rehydrates persisted schema stores after an in-memory reset without exposing schema metadata", async () => {
     const invokeMock = vi.mocked(invoke);
     const storage = await import("./clientStorage");

--- a/src/services/clientStorage.ts
+++ b/src/services/clientStorage.ts
@@ -17,32 +17,52 @@ const dirtyKeys: Partial<Record<ClientStoreName, Set<string>>> = {};
 const pendingFullReplace: Partial<Record<ClientStoreName, boolean>> = {};
 const writeChainByStore: Partial<Record<ClientStoreName, Promise<void>>> = {};
 
+const loadedStores = new Set<ClientStoreName>();
+const inFlightStoreLoads: Partial<Record<ClientStoreName, Promise<void>>> = {};
+
+async function loadStoreIntoCache(store: ClientStoreName): Promise<void> {
+  try {
+    const raw = await invoke<unknown>("client_store_read", { store });
+    const normalized = normalizeClientStoreSnapshot(raw);
+    if (normalized.recoveryReason) {
+      queueMicrotask(() => {
+        writeClientStoreData(store, normalized.data, { immediate: true });
+      });
+    }
+    cache[store] = normalized.data;
+  } catch {
+    cache[store] = {};
+  }
+  loadedStores.add(store);
+}
+
+/**
+ * Load a single client store into the in-memory cache. Idempotent and
+ * de-duplicated: concurrent callers share one in-flight read, and a store
+ * already loaded (here or via {@link preloadClientStores}) resolves instantly.
+ * Lets early consumers (e.g. i18n startup) read the store they need without
+ * waiting on the full preload.
+ */
+export async function loadClientStore(store: ClientStoreName): Promise<void> {
+  if (loadedStores.has(store)) {
+    return;
+  }
+  const existing = inFlightStoreLoads[store];
+  if (existing) {
+    return existing;
+  }
+  const load = loadStoreIntoCache(store).finally(() => {
+    delete inFlightStoreLoads[store];
+  });
+  inFlightStoreLoads[store] = load;
+  return load;
+}
+
 export async function preloadClientStores(): Promise<void> {
   if (preloaded) {
     return;
   }
-  const results = await Promise.all(
-    ALL_CLIENT_STORES.map(async (store) => {
-      try {
-        const raw = await invoke<unknown>(
-          "client_store_read",
-          { store },
-        );
-        const normalized = normalizeClientStoreSnapshot(raw);
-        if (normalized.recoveryReason) {
-          queueMicrotask(() => {
-            writeClientStoreData(store, normalized.data, { immediate: true });
-          });
-        }
-        return [store, normalized.data] as const;
-      } catch {
-        return [store, {}] as const;
-      }
-    }),
-  );
-  for (const [store, data] of results) {
-    cache[store] = data;
-  }
+  await Promise.all(ALL_CLIENT_STORES.map((store) => loadClientStore(store)));
   preloaded = true;
 }
 
@@ -52,8 +72,10 @@ export function isPreloaded(): boolean {
 
 export function resetClientStorageForTests(): void {
   preloaded = false;
+  loadedStores.clear();
   for (const store of ALL_CLIENT_STORES) {
     delete cache[store];
+    delete inFlightStoreLoads[store];
     if (pendingTimers[store] != null) {
       clearTimeout(pendingTimers[store]);
       delete pendingTimers[store];

--- a/src/services/clientStorage.ts
+++ b/src/services/clientStorage.ts
@@ -31,6 +31,9 @@ async function loadStoreIntoCache(store: ClientStoreName): Promise<void> {
     }
     cache[store] = normalized.data;
   } catch {
+    // Pre-existing semantics, carried over from the old preloadClientStores:
+    // a failed read still marks the store loaded (empty cache), so it's not
+    // retried this session. Unchanged behavior, just reachable earlier now.
     cache[store] = {};
   }
   loadedStores.add(store);

--- a/src/services/migrateLocalStorage.test.ts
+++ b/src/services/migrateLocalStorage.test.ts
@@ -7,6 +7,7 @@ const clientStorageMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("./clientStorage", () => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   writeClientStoreData: clientStorageMocks.writeClientStoreData,
   getClientStoreFullSync: clientStorageMocks.getClientStoreFullSync,
 }));

--- a/src/services/rendererDiagnostics.test.ts
+++ b/src/services/rendererDiagnostics.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const clientStorageMocks = vi.hoisted(() => ({
+  loadClientStore: vi.fn(() => Promise.resolve()),
   getClientStoreSync: vi.fn(),
   isPreloaded: vi.fn(),
   writeClientStoreValue: vi.fn(),

--- a/src/test/vitest.setup.ts
+++ b/src/test/vitest.setup.ts
@@ -1284,6 +1284,7 @@ vi.mock("../services/clientStorage", () => {
   const cache: Record<string, Record<string, unknown>> = {};
   return {
     preloadClientStores: vi.fn(() => Promise.resolve()),
+    loadClientStore: vi.fn(() => Promise.resolve()),
     isPreloaded: vi.fn(() => true),
     getClientStoreSync: vi.fn((store: string, key: string) => {
       return cache[store]?.[key];


### PR DESCRIPTION
## 摘要

Fixes #1085: the saved UI language reset to `zh` on every restart. `i18nReady` read the saved language via a synchronous cache lookup that raced the bootstrap store preload - on a fresh process the cache was still empty at that point, so the read silently fell back to the default instead of the user's saved choice.

## 变更类型

- [ ] feature
- [x] fix
- [ ] refactor / 结构治理
- [ ] docs
- [ ] chore / CI

## AppShell / Domain 状态（若涉及 `src/app-shell/**` 或 shell domain bag）

N/A - no `src/app-shell/**` changes.

## 测试

- [x] 相关 unit / vitest: `npx vitest run src/i18n/index.test.ts src/services/clientStorage.test.ts` - 13 tests, all pass
- [x] `npm run check:runtime-contracts`（含 app-shell governance）- pass
- [x] 其它受影响 gate：`npm run typecheck` - clean

## 风险与回滚

- 风险：low. Isolated to the i18n bootstrap read path; `loadClientStore` is additive (a de-duplicated single-store loader that `preloadClientStores` now delegates to, same end result, same failure semantics on a failed read).
- 回滚：revert the two commits; no data migration involved.

---

`src/services/clientStorage.ts` gains `loadClientStore(store)`: an idempotent, de-duplicated per-store loader (concurrent callers share one in-flight read; an already-loaded store resolves instantly). `preloadClientStores` now delegates to it instead of duplicating the read logic. `i18nReady` awaits `loadClientStore("app")` before reading the saved language, closing the race.

Why a new function instead of just `await preloadClientStores()` from i18n? The old `preloadClientStores` had no in-flight dedup - a second concurrent call re-read every store from scratch. Awaiting it directly from i18n would have meant every store gets read twice at startup (once for i18n's own trigger, once for the app's real preload). `loadClientStore` fixes that: i18n only waits on the one store it needs, and if the full preload is already in flight, the "app" store's read is shared, not duplicated.

Every test file whose module graph touches the real `i18n` singleton needed a small addition: a `vi.mock` factory must return every export its consumers import, and `src/i18n/index.ts` now calls `loadClientStore` at module init. This touched every test file mocking `services/clientStorage` (including the suite's own global default mock in `src/test/vitest.setup.ts`) - each got the same one-line `loadClientStore: vi.fn(() => Promise.resolve())` stub. Mechanical, no behavior change in any of those files.

While fixing this, I noticed the same file gets mocked the same way in ~40 places across the suite. Happy to open a follow-up PR adding a small set of shared default stubs (spread into each site's existing mock, not a replacement) if that'd help avoid this kind of fan-out next time a `clientStorage` export gets added - no pressure either way, skip it if you'd rather keep things as-is.

This PR is deliberately scoped to only the race fix. A separate, dependent change that makes the *default* (when nothing is saved at all) follow the OS locale instead of always `zh` is intentionally left out and will follow as its own PR, since that's a product decision, not a bug fix.
