### PR TITLE
fix(claude): bound the pre-result wait for a pending background agent task

### DIFF
--- a/openspec/changes/fix-claude-agent-pending-task-unbounded-wait/.openspec.yaml
+++ b/openspec/changes/fix-claude-agent-pending-task-unbounded-wait/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-15

--- a/openspec/changes/fix-claude-agent-pending-task-unbounded-wait/design.md
+++ b/openspec/changes/fix-claude-agent-pending-task-unbounded-wait/design.md
@@ -1,0 +1,162 @@
+## Context
+
+### What the CLI actually does with `result` when a background Agent/Task is pending
+
+The intuitive model of this code path is wrong in a way that matters, so the evidence is recorded
+here in full.
+
+Three in-app reproductions were run against a confirmed pre-fix binary, each starting a background
+Agent/Task subagent doing real single-command work with no artificial `sleep`:
+
+| Run | Subagent task | Duration | Outcome |
+|---|---|---|---|
+| 1 | Read 43 source files and summarise | 112s | Delivered successfully |
+| 2 | `find / -xdev -type f \| wc -l` | 37.5s | Delivered successfully |
+| 3 | `find / -xdev -type f \| xargs md5sum \| wc -l` | 502s | Delivered successfully, PID-verified |
+
+For run 3, `ps -eo pid,ppid,lstart,cmd` captured the handling process's PID and start time before
+launch, and again in the turn triggered by `task_notification`. Both were identical across 510
+seconds: the same OS process throughout, never killed and never replaced by a `--resume` restart.
+
+Reading the raw stream captures line by line gives the decisive detail. An 80-line capture of a
+single background `general-purpose` subagent:
+
+```
+L37        system/background_tasks_changed   (task registered)
+L38        system/task_started task_id=a68e1c0cd56b98ac9
+L39        user                              (async-launch tool result)
+L44,48,49  assistant                         (turn "appears" finished here)
+L50-52     background_tasks_changed[] / task_updated status=completed / task_notification completed
+L71,75     assistant                         (reply to the notification)
+L79        result #1  subtype=success num_turns=2 duration_ms=3643
+L80        result #2  origin={"kind":"task-notification"} num_turns=1 duration_ms=3035
+```
+
+Searching that file for `"type":"result"` matches only L79 and L80: **no `result` event appears
+before `task_notification`.** `result #1`'s `duration_ms=3643` also exceeds the notification's own
+`usage.duration_ms=1373`, showing it was emitted at the end of the whole turn rather than at the
+first assistant reply. A second capture has the identical structure (`task_started` at L38,
+`task_notification` at L55, `result` only at L112/113).
+
+**Conclusion: the CLI defers the turn's `result` until every pending background Agent task has
+settled, then emits both `result` events back to back.** This is the opposite of the Bash background
+shell case handled by #983, where `result` arrives normally while the shell is still running, which
+is exactly why #983 needs its blocker mechanism.
+
+### Why that makes the post-result path unreachable here
+
+`result_seen_at` is only set when the first `type=="result"` is seen (`claude.rs:2044-2047`). Since
+the turn never emits `result` early, `result_seen_at` stays `None` for the entire lifetime of the
+background task. `post_result_grace_deadline`'s `get_or_insert_with` and the grace decision
+(`can_force_kill_for_grace`) are therefore never reached. This is not a race that happens to be won;
+the precondition simply never holds.
+
+For that whole period the wait loop sits in the `saw_valid_stream_event == true &&
+result_seen_at.is_none()` branch, which is a bare `lines.next_line().await` around
+`claude.rs:1868-1869` with **no timeout wrapper at all**.
+
+### The reachable gap
+
+If a background subagent crashes or hangs without ever emitting its terminal `task_notification`,
+the CLI will most likely never emit `result` either, since it is waiting on the same event. That
+bare `next_line().await` then blocks permanently, with no automatic convergence path and the UI
+stuck in "generating".
+
+## Decision
+
+Introduce pending-task tracking that is **independent of** `active_background_task_ids`, serving
+only the pre-result branch:
+
+- **Tracking state**: a new `pending_agent_task_ids: HashSet<String>`, structurally like
+  `active_background_task_ids` but a separate variable. It reuses the existing
+  `extract_task_started_id` to recognise `task_started` and `extract_terminal_task_release_id` to
+  recognise terminal `task_notification`, inserting and removing respectively. Both helpers are
+  symmetric and already test-covered; the only change is that they no longer write to
+  `active_background_task_ids`.
+- **A bounded wait that is IDLE, not absolute**: `pending_agent_task_deadline: Option<Instant>` is
+  armed via `get_or_insert_with(|| Instant::now() + CLAUDE_BG_TASK_MAX_WAIT)` when
+  `pending_agent_task_ids` first becomes non-empty, **and is reset to
+  `Instant::now() + CLAUDE_BG_TASK_MAX_WAIT` on every successfully parsed stream event received
+  while the set is non-empty**. Any event at all is evidence the process is alive and producing.
+  A genuinely working subagent therefore never trips the bound however long it runs in total; only a
+  full `CLAUDE_BG_TASK_MAX_WAIT` window with no new line does. While
+  `saw_valid_stream_event == true && result_seen_at.is_none()` and the set is non-empty, the
+  `lines.next_line().await` is wrapped in `tokio::time::timeout(remaining, ...)`. On expiry it takes
+  the existing `settled_by_grace = true; break;` convergence path, sharing downstream handling with
+  the established grace-kill rather than adding a new failure mode, and additionally sets
+  `settled_by_pending_task_max_wait`. Clearing the set clears the deadline, so a later pending task
+  in the same turn re-arms it.
+
+  An absolute deadline was implemented first and rejected on review: it would kill a healthy
+  long-running subagent indiscriminately, which is precisely the class of harm this change exists to
+  prevent.
+- **A force-kill must not be silent**: when `settled_by_pending_task_max_wait` is set and
+  `response_text` is still empty, `response_text` is replaced before `TurnCompleted` with an explicit
+  "the background subagent did not report back in time and was abandoned" notice, so the turn does
+  not look identical to a normal empty result. Real content is never overwritten; the notice is only
+  written when there is genuinely nothing.
+- **The post-result `WaitBgTasks` path is untouched**, keeping #983's unbounded
+  `lines.next_line().await`. `active_background_task_ids` continues to serve only the Bash
+  `backgroundTaskId` source and is never fed by `task_started`.
+- **No pending task means no change**: when `pending_agent_task_ids` is empty, the
+  `result_seen_at.is_none()` branch keeps its current bare wait, so a legitimate long turn with no
+  background task involved is unaffected.
+
+The separate set is the key structural point. Coupling "does this turn have a pending background
+task" to "should the post-result wait block indefinitely" would let a signal that should only affect
+the pre-result stage silently change post-result behavior. The two branches have genuinely different
+risk models: pre-result, the CLI itself is waiting and what is missing is our own timeout for when
+it wedges; post-result, the CLI considers the turn finished and the question is whether to keep
+holding the process open for a background task. Two independent pieces of state keep each change
+confined to its own branch.
+
+## Known limitations
+
+- Two overlapping pending tasks share a single deadline, so the later-arriving task can be abandoned
+  earlier than its own full window would allow. The impact is small and this change does not address
+  it.
+- The trigger requires the CLI process to stay alive while its internal task tracking wedges
+  permanently. That is a narrower condition than "the subagent crashed", and it has not been
+  observed in practice. This change is defensive hardening against an unbounded wait, not a fix for
+  an observed failure.
+- `interrupt()` and the Stop button already recover a hung turn manually today. What is missing is
+  automatic recovery, not any recovery at all.
+- Background work lost *between* turns is a structurally different problem and is untouched here.
+
+## Alternatives
+
+- **A. Register into `active_background_task_ids` and bound the post-result `WaitBgTasks`.**
+  Rejected: the reproductions above show the post-result branch is never entered while an Agent/Task
+  is pending, making this dead code on the happy path, and bounding `WaitBgTasks` regresses #983,
+  which chose unbounded deliberately.
+- **B. Reuse the same `active_background_task_ids` set for the pre-result branch.** Saves one
+  variable. Rejected: couples two independent wait semantics to one signal source, so a future
+  change to either path can silently affect the other.
+- **C. Bound every pre-result wait unconditionally.** Rejected: kills legitimate slow turns with no
+  background task involved, which is not the risk being addressed.
+  `CLAUDE_STREAM_FIRST_EVENT_TIMEOUT` (90s, covering "no events at all") is already this branch's
+  existing, well-scoped protection and should not be replaced by a general bound.
+- **D (adopted). Independent pending tracking, bounding only the pre-result branch.** See Decision.
+  Targets the reachable gap precisely with no coupling or regression, reusing both existing helpers.
+
+## Validation
+
+- fake-stream: `task_started` followed by neither a terminal notification nor a `result` triggers the
+  new pre-result max-wait, sets `settled_by_grace=true`, and converges instead of hanging.
+- fake-stream: `task_started` plus a matching terminal notification before `result` (the real
+  observed order) clears `pending_agent_task_ids` in time, does not trigger the bound, and completes
+  through the existing post-result branch, where `active_background_task_ids` is empty because the
+  Bash path is unaffected.
+- fake-stream: a normal long turn with no `task_started` is unaffected, with
+  `pending_agent_task_ids` empty throughout and the bare wait behaving as it does today.
+- fake-stream: a pending task emitting an activity event every 1.5s for 4.5s, past the raw test
+  bound, is not killed and ends normally with `result`, proving the bound is idle-based.
+- fake-stream: the existing #983 Bash `backgroundTaskId` regressions stay green with post-result
+  `WaitBgTasks` still unbounded.
+- `openspec validate fix-claude-agent-pending-task-unbounded-wait --strict --no-interactive` passes.
+
+## Open questions
+
+- The `CLAUDE_BG_TASK_MAX_WAIT` value is reused unchanged from the existing production and test
+  values. Only its application point is new (the pre-result branch), so the original reasoning still
+  holds and is not re-derived here.

--- a/openspec/changes/fix-claude-agent-pending-task-unbounded-wait/proposal.md
+++ b/openspec/changes/fix-claude-agent-pending-task-unbounded-wait/proposal.md
@@ -1,0 +1,113 @@
+## Why
+
+When a turn spawns a background Agent/Task subagent, the wait that precedes the turn's own `result`
+event has no timeout at all. If that subagent crashes or hangs without ever emitting a terminal
+`task_notification`, the turn blocks indefinitely and the UI stays in "generating" forever, with no
+automatic recovery path.
+
+The mechanism is specific, and worth stating precisely because the obvious diagnosis is wrong:
+
+- The CLI **defers** the current turn's `result` event until every pending background Agent/Task
+  subagent has settled, then emits them together. The observed order is constant: `task_started` ->
+  `task_notification` -> the turn's `result`.
+- `claude.rs`'s `CLAUDE_POST_RESULT_GRACE` grace-kill only arms once `result_seen_at.is_some()`
+  (via `post_result_grace_deadline`'s `get_or_insert_with`). Because of the deferral above, that
+  precondition is never true while a background task is pending, so no post-result mechanism engages
+  for this case at all.
+- The reachable gap is therefore in the other branch: while `result_seen_at` is `None`
+  (`saw_valid_stream_event` already true, `result` not yet seen), the wait falls through to a bare
+  `lines.next_line().await` around `claude.rs:1868-1869` with no timeout protection.
+
+This was established by three in-app reproductions on a confirmed pre-fix binary, running a real
+single-command background subagent with no `sleep`: the three runs took 112s, 37.5s and 502s and
+**all three delivered successfully, never killed**. A `ps -eo pid,ppid,lstart,cmd` snapshot taken
+before and after the third run showed an identical PID and start time across 510 seconds, proving
+the process was never killed and never restarted. The raw stream captures confirm the deferral
+order above. Details in `design.md`.
+
+## Goals and Scope
+
+- Bound only the reachable gap: the wait while `result_seen_at` is `None` **and** a background
+  Agent/Task subagent is pending, using `CLAUDE_BG_TASK_MAX_WAIT`.
+- Track that pending state in a set that is **independent of** `active_background_task_ids` (the
+  existing set that serves only the post-result `WaitBgTasks` path, issue #983), so the two waits
+  cannot affect one another.
+- Leave `active_background_task_ids` and the post-result `WaitBgTasks` path completely unchanged,
+  preserving #983's deliberately unbounded behavior.
+- When no background task is pending, this wait loop keeps its current behavior (genuinely
+  unbounded, no new timeout). A slow but healthy long turn with no background task is unaffected.
+- Claude Local CLI engine path only.
+
+## Non-Goals
+
+- No PreToolUse deny mechanism.
+- No change to #983's own proposal, design, spec, or behavior.
+- No dedicated "waiting for agent" UI copy (a pre-existing P1 item, still deferred).
+- No re-derivation of the `CLAUDE_BG_TASK_MAX_WAIT` value itself. The existing 30-minute production
+  value is reused unchanged; only the place it is applied is new.
+
+## What Changes
+
+- `claude_stream_helpers.rs`: `extract_task_started_id` (symmetric with the existing release logic,
+  recognising `task_started` events) is wired to a **new, independent** pending-task set and
+  deadline rather than to `active_background_task_ids`.
+- `claude.rs`:
+  - In the `result_seen_at.is_none()` branch (around `claude.rs:1868-1869`), wrap the wait in
+    `tokio::time::timeout` whenever the new pending set is non-empty. On expiry, converge via the
+    existing `settled_by_grace = true; break;` path, reusing the established force-kill mechanism
+    rather than introducing a new failure mode.
+  - The deadline is an **idle** bound, not an absolute one: it resets on every stream event received
+    while the task is pending, so a genuinely active long-running subagent is not killed.
+  - When force-kill does fire and `response_text` is empty, write a visible
+    `settled_by_pending_task_max_wait` notice rather than reporting a silent empty success.
+  - With no pending task, the branch keeps its current bare `next_line().await`.
+- Tests: fake-stream coverage for (a) `task_started` with no terminal notification and no `result`,
+  converging at the bound; (b) `task_started` plus a terminal notification arriving before `result`
+  in the real observed order, not triggering the bound; (c) a normal long turn with no background
+  task, unaffected; (d) the existing #983 Bash-path regressions staying green with `WaitBgTasks`
+  still unbounded; (e) an idle-reset case proving the bound is idle-based rather than absolute.
+
+### Alternatives considered
+
+| Option | Description | Trade-off |
+|------|------|------|
+| A. Extend the #983 register side and bound the post-result wait | Bound the wait that fires after `result` | **Rejected**: the reproductions above show the post-result path is never armed while a background task is pending, so this is dead code on the happy path, and it regresses #983 by bounding a wait that was deliberately unbounded |
+| B. Reuse the `active_background_task_ids` set for the pre-result branch too | Saves introducing a new set | **Rejected**: couples two independent wait semantics onto one set, so a future change to either path can silently affect the other |
+| C. Bound every pre-result wait unconditionally | No pending-task condition | **Rejected**: kills legitimate slow turns with no background task involved (long model reasoning or output), which is not the risk being addressed |
+| **D (adopted). Independent pending tracking, bound only the pre-result branch** | A dedicated set and deadline serving this branch only; post-result `WaitBgTasks` untouched | **Adopted**: targets the reachable gap precisely, introduces no coupling or regression, and is small (one set plus one timeout branch) while reusing the existing force-kill convergence path |
+
+## Capabilities
+
+### New Capabilities
+
+- `claude-agent-pending-task-liveness-bound`: the bounded-wait contract for the window where
+  `result_seen_at` is `None` and a pending Agent/Task `task_started` exists. It sits alongside
+  #983's `claude-background-task-settlement` (post-result `WaitBgTasks`) and does not modify it.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+| Layer | Effect |
+|----|--------|
+| Backend | `claude_stream_helpers.rs` (reuse `extract_task_started_id`, wired to the new set); `claude.rs` (new bounded pre-result wait branch) |
+| Frontend | No expected change |
+| Specs | Adds `claude-agent-pending-task-liveness-bound`; #983's own delta is untouched |
+| Dependencies | Structurally depends on #983's register/release/grace mechanism, already on `main` |
+
+## Acceptance Criteria
+
+1. fake-stream: a `task_started` that is never followed by a terminal notification or a `result`
+   still converges via force-kill at the `CLAUDE_BG_TASK_MAX_WAIT` bound instead of blocking
+   indefinitely.
+2. fake-stream: `task_started` plus a matching terminal notification before `result` (the real
+   observed order) does not trigger the bound, and the turn completes through the existing path.
+3. fake-stream: a normal long turn with no background task behaves exactly as it does today.
+4. fake-stream: a pending task that keeps emitting stream events past the raw bound is **not**
+   killed, proving the deadline is idle-based rather than absolute.
+5. The existing #983 Bash-path regressions stay green, with post-result `WaitBgTasks` still
+   unbounded.
+6. A force-kill with empty `response_text` produces a visible notice, not a silent empty success.
+7. `openspec validate fix-claude-agent-pending-task-unbounded-wait --strict --no-interactive` passes.

--- a/openspec/changes/fix-claude-agent-pending-task-unbounded-wait/specs/claude-agent-pending-task-liveness-bound/spec.md
+++ b/openspec/changes/fix-claude-agent-pending-task-unbounded-wait/specs/claude-agent-pending-task-liveness-bound/spec.md
@@ -1,0 +1,106 @@
+## ADDED Requirements
+
+### Requirement: Pending Agent/Task Subagents Are Tracked Independently Of Post-Result Blockers
+
+When the current turn's stream emits a `type: "system", subtype: "task_started"` event before that turn's own `result` event has been seen, ccgui MUST register that event's `task_id` in a dedicated pending-task tracking set that is independent of the `active_background_task_ids` set used by `claude-background-task-settlement` (issue #983) for its post-result `WaitBgTasks` behavior.
+
+This separation exists because the two waits have different risk models: the post-result wait
+(#983) exists because the CLI's own `result` event can arrive while a Bash background shell is
+still running, and #983 deliberately leaves that wait unbounded. The pre-result wait this
+requirement covers exists because, for Agent/Task subagents, the CLI observably defers its own
+`result` event until every pending background task has settled, so `result_seen_at` never becomes
+`Some` while such a task is pending, and the existing post-result mechanisms never engage for this
+case at all.
+
+#### Scenario: a background Agent/Task call registers a pending-task entry before `result`
+
+- **WHEN** the current turn's stream emits `{"type":"system","subtype":"task_started","task_id":"<id>",...}`
+- **AND** the turn's `result` event has not yet been seen
+- **THEN** ccgui MUST add `<id>` to a dedicated pending-task tracking set, separate from
+  `active_background_task_ids`
+- **AND** MUST NOT add it to `active_background_task_ids`
+
+#### Scenario: a matching terminal task-notification clears the pending-task entry
+
+- **GIVEN** `<id>` is present in the pending-task tracking set
+- **WHEN** the stream emits a matching terminal `task_notification` for `task_id = "<id>"`
+  (`status` completed/failed/stopped)
+- **THEN** ccgui MUST remove `<id>` from the pending-task tracking set, using the same terminal-
+  status matching logic `claude-background-task-settlement` already defines for its own release
+  path
+- **AND** any subsequent stream content produced as part of that notification's continuation
+  (`origin.kind == "task-notification"`) MUST be appended into the same turn's response, using the
+  existing post-result text-delta accumulation path once `result` is eventually seen
+
+### Requirement: The Pre-Result Wait Has An Idle Maximum When A Task Is Pending
+
+While the pending-task tracking set is non-empty and the turn's `result` event has not yet been seen, the stream-read wait MUST be bounded by `CLAUDE_BG_TASK_MAX_WAIT` as an IDLE bound, not an absolute one: the deadline MUST reset to `now + CLAUDE_BG_TASK_MAX_WAIT` on every successfully parsed stream line received while the pending-task tracking set remains non-empty, so a subagent that is genuinely still producing activity never trips it regardless of total elapsed duration. Only a stream that goes fully silent for the entire `CLAUDE_BG_TASK_MAX_WAIT` window trips the bound. When the pending-task tracking set is empty, this wait MUST remain unbounded (matching today's behavior for a normal turn with no background task involved).
+
+An absolute (arm-once, never-reset) bound was rejected during review: it would force-kill a legitimately long-running, still-active background subagent and report the turn as success with no visible indication anything was destroyed, trading a visible, user-recoverable hang (today's Stop button already works) for a silent, unrecoverable one. See the force-killed-turn-must-be-visible requirement below.
+
+#### Scenario: a pending task that goes fully idle is force-killed after the idle max-wait
+
+- **GIVEN** the pending-task tracking set is non-empty (a `task_started` was seen, no matching
+  terminal notification yet)
+- **AND** the turn's `result` event has not been seen
+- **WHEN** `CLAUDE_BG_TASK_MAX_WAIT` elapses with no stream line received in that window, the set
+  not clearing, and stdout not reaching EOF
+- **THEN** ccgui MUST force-kill the process tree via the existing grace-kill path
+- **AND** MUST treat this the same as an existing grace-kill for exit-status/settlement purposes
+  (not a new failure mode)
+
+#### Scenario: a pending task that keeps producing activity is never force-killed regardless of total duration
+
+- **GIVEN** the pending-task tracking set is non-empty
+- **WHEN** at least one stream line is received at intervals shorter than `CLAUDE_BG_TASK_MAX_WAIT`,
+  for a total duration exceeding `CLAUDE_BG_TASK_MAX_WAIT`
+- **THEN** ccgui MUST NOT force-kill the process tree, no matter how long this continues
+- **AND** the turn continues waiting for `result` exactly as it does today when no background task
+  was ever involved
+
+#### Scenario: a pending task that settles before the idle max-wait bound is unaffected
+
+- **WHEN** the pending-task tracking set clears (or stdout reaches EOF) before
+  `CLAUDE_BG_TASK_MAX_WAIT` elapses since the last received line
+- **THEN** no force-kill occurs from this requirement
+- **AND** the turn continues waiting for `result` exactly as it does today when no background task
+  was ever involved
+
+### Requirement: A Force-Killed Pending Task Must Never Look Like A Silent Empty Success
+
+When the idle max-wait force-kills the process tree while `response_text` would otherwise be empty, ccgui MUST synthesize a visible notice into the turn's response text rather than completing the turn with silent empty content. An abandoned background subagent MUST be distinguishable from an ordinary turn that legitimately produced no text. This MUST NOT overwrite any real partial response content the stream already produced before the subagent went silent.
+
+#### Scenario: an idle-abandoned pending task with no other content gets a visible notice
+
+- **GIVEN** the idle max-wait force-kills the process tree per the requirement above
+- **AND** `response_text` is empty at that point
+- **THEN** ccgui MUST replace `response_text` with a notice indicating a background subagent did
+  not report back and was abandoned
+- **AND** the turn MUST still complete (`TurnCompleted`), not error, so the notice is visible to
+  the user
+
+#### Scenario: real partial content is preserved, not overwritten by the notice
+
+- **GIVEN** the idle max-wait force-kills the process tree per the requirement above
+- **AND** `response_text` already contains real content produced earlier in the same turn
+- **THEN** ccgui MUST NOT overwrite that content with the abandonment notice
+
+#### Scenario: a turn with no pending Agent/Task subagent is never bounded by this requirement
+
+- **GIVEN** the pending-task tracking set has been empty for the entire turn
+- **WHEN** the turn's `result` event has still not been seen after an arbitrarily long duration
+- **THEN** ccgui MUST NOT force-kill the process tree under this requirement
+- **AND** the existing unbounded wait behavior for a long-running turn is preserved unchanged
+
+### Requirement: The Post-Result Bash Background-Shell Wait Remains Unbounded
+
+`claude-background-task-settlement`'s (#983) post-result `WaitBgTasks` behavior, gated by `active_background_task_ids`, MUST remain unbounded. This requirement is stated explicitly because bounding the pre-result wait invites the symmetric change on the post-result path, and that symmetry does not hold: no evidence supports bounding the Bash background-shell path, where the CLI emits `result` while the shell is still running, and #983 deliberately chose to leave it unbounded.
+
+#### Scenario: a long-running Bash background shell after `result` is not force-killed by a max-wait bound
+
+- **GIVEN** `active_background_task_ids` is non-empty after the turn's `result` event (a Bash
+  background shell registered via `backgroundTaskId`)
+- **WHEN** an arbitrarily long duration elapses without the blocker releasing
+- **THEN** ccgui MUST NOT force-kill the process tree due to any maximum-wait bound
+- **AND** MUST continue waiting until the blocker releases, EOF is reached, or the user stops the
+  turn (the pre-existing #983 behavior, unmodified)

--- a/openspec/changes/fix-claude-agent-pending-task-unbounded-wait/tasks.md
+++ b/openspec/changes/fix-claude-agent-pending-task-unbounded-wait/tasks.md
@@ -1,0 +1,70 @@
+## 1. OpenSpec
+
+- [x] 1.1 [P0] Author proposal / design / tasks / spec around an independent pre-result pending-task
+      tracker rather than reusing `active_background_task_ids`
+- [x] 1.2 [P0] `openspec validate fix-claude-agent-pending-task-unbounded-wait --strict --no-interactive`
+
+## 2. Backend
+
+- [x] 2.1 [P0] `claude.rs`: confirm the post-result `WaitBgTasks` branch keeps #983's unbounded
+      `lines.next_line().await`. Verified by grep that `CLAUDE_BG_TASK_MAX_WAIT` did not previously
+      appear in this file, so no revert was required
+- [x] 2.2 [P0] `claude.rs`: add `pending_agent_task_ids: HashSet<String>` and
+      `pending_agent_task_deadline: Option<Instant>`, and wire the bounded wait into the
+      `result_seen_at.is_none()` branch, reusing `CLAUDE_BG_TASK_MAX_WAIT`. Both wait branches
+      (empty buffer and non-empty `pending_text_delta`) are covered
+- [x] 2.3 [P0] `claude_stream_helpers.rs` / `claude.rs`: add `extract_task_started_id` (symmetric
+      with the existing `extract_terminal_task_release_id`), reusing
+      `try_register_background_task_id` / `try_release_background_task_id`, wired to
+      `pending_agent_task_ids` only, never to `active_background_task_ids`
+- [ ] 2.4 [P1] Optional follow-up: treat `background_tasks_changed` (the all-clear event with
+      `tasks:[]` seen in stream captures) as an additional signal for clearing
+      `pending_agent_task_ids`. Not implemented
+- [x] 2.5 [P0] Make the deadline an IDLE bound rather than an absolute one: it resets on every
+      stream event received while a task is pending. An absolute deadline would kill a healthy
+      long-running subagent and then report success silently. When force-kill fires and
+      `response_text` is empty, write a visible `settled_by_pending_task_max_wait` notice instead
+- [x] 2.6 [P0] `cargo check` and `cargo test --lib` verified on a Linux CI runner rather than
+      locally. `cargo check` passes clean. The first real `cargo test --lib` run surfaced three
+      incorrect assertions in the new tests themselves (not defects in `claude.rs`); after fixing
+      those, results match the pre-existing baseline failure set with no new failures
+
+## 3. Tests
+
+- [x] 3.1 [P0] fake-stream `send_message_force_settles_pending_agent_task_that_never_notifies`:
+      `task_started` with no terminal notification and no `result` converges once the pre-result
+      idle max-wait (3s under test) expires, rather than hanging; asserts the response text carries
+      the visible give-up notice rather than being empty
+- [x] 3.2 [P0] fake-stream `send_message_pending_agent_task_settles_normally_before_result`:
+      `task_started` plus a terminal notification before `result` (the real observed order) does not
+      trigger the new max-wait (elapsed < 2s) and completes through the existing path
+- [x] 3.3 [P0] fake-stream `send_message_unaffected_turn_survives_past_pending_task_max_wait`: a
+      normal long turn with no `task_started` (elapsed >= 4s, past the 3s test bound) is unaffected
+- [x] 3.4 [P0] Existing #983 Bash-path regressions (including
+      `send_message_waits_past_grace_when_structured_background_task_active`) stay green unmodified.
+      Since 2.1 is a no-op, there is no separate "restored to unbounded" assertion to add; those
+      tests already sleep 7s, past the 3s test bound, which demonstrates independence from
+      `CLAUDE_BG_TASK_MAX_WAIT`
+- [x] 3.5 [P0] fake-stream `send_message_pending_agent_task_idle_reset_survives_past_raw_max_wait`:
+      emits an activity event every 1.5s for 4.5s, past the raw 3s test bound, and asserts the turn
+      is not killed and ends normally with `result`, proving the bound is idle-based
+- [ ] 3.6 [P1] In-app reproduction: kill a background subagent process mid-flight and confirm the
+      turn hangs before the change and converges after it. Not done; recorded as a known limitation
+      rather than a blocker
+
+## 4. Wrap-up
+
+- [ ] 4.1 [P0] `openspec-verify-change`
+- [ ] 4.2 [P1] Open the upstream PR
+- [ ] 4.3 [P1] Separate follow-up, not addressed here: background work lost *between* turns is a
+      structurally different problem from the within-turn settlement this change bounds. It remains
+      unreproduced and uninvestigated; merging this change does not close it
+
+## Non-tasks (explicitly out of scope)
+
+- A native PreToolUse deny path
+- Dedicated "waiting for agent" UI copy (P1, carried over from #983)
+- Re-deriving the `CLAUDE_BG_TASK_MAX_WAIT` value; the existing value is reused, only its
+  application point is new
+- Editing #983's own proposal / design / spec files; this change depends on its mechanism but does
+  not modify it

--- a/src-tauri/src/engine/claude.rs
+++ b/src-tauri/src/engine/claude.rs
@@ -85,7 +85,7 @@ use stream_helpers::extract_tool_result_text;
 use stream_helpers::{
     can_force_kill_for_grace, extract_background_task_id, extract_claude_tool_input,
     extract_claude_tool_name, extract_result_text, extract_string_field,
-    extract_terminal_task_release_id, is_claude_stream_control_line,
+    extract_task_started_id, extract_terminal_task_release_id, is_claude_stream_control_line,
     looks_like_claude_runtime_error, merge_text_chunks, parse_claude_stream_json_line,
     tool_input_signature, try_register_background_task_id, try_release_background_task_id,
 };
@@ -314,6 +314,20 @@ const CLAUDE_STREAM_DIAGNOSTIC_SAMPLE_LIMIT: usize = 800;
 // processes or hooks keep the CLI alive, the UI would otherwise stay stuck on
 // "generating…" indefinitely. This grace caps how long we wait after `result`.
 const CLAUDE_POST_RESULT_GRACE: Duration = Duration::from_secs(5);
+// Before `result` is seen, the stream-read wait is normally unbounded by design (a legitimate
+// turn can run a long time with no risk indicator present). But the CLI observably defers this
+// turn's own `result` event until every pending Agent/Task subagent (`run_in_background: true`)
+// has settled (see the probe evidence in this change's design.md Context section), so a
+// subagent that crashes or hangs without ever emitting a terminal `task_notification` leaves this wait
+// genuinely unbounded with no recovery path. This constant caps ONLY that specific pre-result
+// window, and only while a pending Agent/Task subagent (task_started, no matching terminal
+// notification yet) has actually been observed; a normal turn with no background task involved
+// is never subject to it. Deliberately generous, not a practical ceiling for legitimate
+// long-running background work.
+#[cfg(not(test))]
+const CLAUDE_BG_TASK_MAX_WAIT: Duration = Duration::from_secs(30 * 60);
+#[cfg(test)]
+const CLAUDE_BG_TASK_MAX_WAIT: Duration = Duration::from_secs(3);
 // Draining the stderr reader must be bounded for the same reason as the stdout
 // wait above: a descendant that escaped the CLI's process group (e.g. an MCP
 // server or Stop hook that called setsid) keeps the inherited stderr write end
@@ -1749,11 +1763,35 @@ impl ClaudeSession {
         // blockers clear after WaitBgTasks → full re-arm from clearance.
         let mut post_result_grace_deadline: Option<Instant> = None;
         // Turn-scoped structured backgroundTaskId set (settlement blockers).
+        // Bash background shells (#983) only. Agent/Task async-launch subagents use
+        // `pending_agent_task_ids` below instead; see that field's doc comment for why
+        // the two are kept independent rather than sharing one set.
         let mut active_background_task_ids: HashSet<String> = HashSet::new();
-        // Set when we stop waiting because the post-result grace elapsed. The
-        // turn is settled as a success (result was already emitted) and the
-        // exit-status failure checks are skipped for the process we force-kill.
+        // Turn-scoped Agent/Task `task_started` ids seen before `result`, independent of
+        // `active_background_task_ids`. Bounds the pre-result wait (see CLAUDE_BG_TASK_MAX_WAIT)
+        // instead of the post-result WaitBgTasks path #983 deliberately leaves unbounded, the two
+        // waits have different risk models (this one exists because the CLI defers `result` for a
+        // pending Agent/Task subagent, so `result_seen_at` never becomes `Some` while one is
+        // outstanding) and must not be coupled onto the same set/timer.
+        let mut pending_agent_task_ids: HashSet<String> = HashSet::new();
+        // Armed the first time `pending_agent_task_ids` becomes non-empty, and RESET on every
+        // received stream line thereafter (see the reset in the event-parse block below), this is
+        // an IDLE bound, not an absolute one: a subagent that's genuinely still producing activity
+        // never hits it, no matter how long it legitimately runs. Only a stream that goes silent
+        // for the full CLAUDE_BG_TASK_MAX_WAIT window (the CLI itself alive, its task tracker
+        // permanently stuck) trips it. Cleared when the set empties (allowing a later task_started,
+        // still pre-result, to re-arm from its own start).
+        let mut pending_agent_task_deadline: Option<Instant> = None;
+        // Set when we stop waiting because the post-result grace elapsed, OR because the pre-result
+        // pending-task idle-wait elapsed. The turn is settled as a success (result was already
+        // emitted, or the pending subagent is abandoned) and the exit-status failure checks are
+        // skipped for the process we force-kill.
         let mut settled_by_grace = false;
+        // Specifically the pre-result pending-task idle-wait (distinct from the post-result grace
+        // path above, which always follows a real `result`): used only to synthesize a visible
+        // notice if `response_text` would otherwise be silently empty; abandoning a background
+        // subagent must never look identical to an ordinary empty-but-successful turn.
+        let mut settled_by_pending_task_max_wait = false;
 
         // Spawn stderr reader
         let stderr_reader = BufReader::new(stderr);
@@ -1810,8 +1848,34 @@ impl ClaudeSession {
                                 }
                             }
                         }
-                    } else {
+                    } else if pending_agent_task_ids.is_empty() {
                         lines.next_line().await
+                    } else {
+                        // A pending Agent/Task subagent (task_started, no matching terminal
+                        // notification yet) is outstanding pre-result. Bound the wait, see
+                        // CLAUDE_BG_TASK_MAX_WAIT's doc comment for why.
+                        let deadline = pending_agent_task_deadline
+                            .get_or_insert_with(|| Instant::now() + CLAUDE_BG_TASK_MAX_WAIT);
+                        let remaining = deadline.saturating_duration_since(Instant::now());
+                        match tokio::time::timeout(remaining, lines.next_line()).await {
+                            Ok(result) => result,
+                            Err(_) => {
+                                if pending_agent_task_ids.is_empty() {
+                                    // Cleared in the same instant the timeout elapsed; continue
+                                    // normally (mirrors the analogous post-result race below).
+                                    continue;
+                                }
+                                log::warn!(
+                                    "[claude] pending Agent/Task idle max-wait ({:?}) elapsed with {} task(s) still pending turn={}; force-settling",
+                                    CLAUDE_BG_TASK_MAX_WAIT,
+                                    pending_agent_task_ids.len(),
+                                    turn_id
+                                );
+                                settled_by_grace = true;
+                                settled_by_pending_task_max_wait = true;
+                                break;
+                            }
+                        }
                     }
                 } else {
                     let wait_duration = first_event_deadline
@@ -1847,6 +1911,11 @@ impl ClaudeSession {
                         .get_or_insert_with(|| Instant::now() + CLAUDE_POST_RESULT_GRACE);
                     wait_duration =
                         wait_duration.min(deadline.saturating_duration_since(Instant::now()));
+                } else if result_seen_at.is_none() && !pending_agent_task_ids.is_empty() {
+                    let deadline = pending_agent_task_deadline
+                        .get_or_insert_with(|| Instant::now() + CLAUDE_BG_TASK_MAX_WAIT);
+                    wait_duration =
+                        wait_duration.min(deadline.saturating_duration_since(Instant::now()));
                 }
                 match tokio::time::timeout(wait_duration, lines.next_line()).await {
                     Ok(result) => result,
@@ -1858,6 +1927,21 @@ impl ClaudeSession {
                         {
                             self.flush_buffered_text_delta(turn_id, &mut pending_text_delta);
                             settled_by_grace = true;
+                            break;
+                        }
+                        if result_seen_at.is_none()
+                            && !pending_agent_task_ids.is_empty()
+                            && pending_agent_task_deadline.is_some_and(|d| Instant::now() >= d)
+                        {
+                            self.flush_buffered_text_delta(turn_id, &mut pending_text_delta);
+                            log::warn!(
+                                "[claude] pending Agent/Task idle max-wait ({:?}) elapsed with {} task(s) still pending turn={}; force-settling",
+                                CLAUDE_BG_TASK_MAX_WAIT,
+                                pending_agent_task_ids.len(),
+                                turn_id
+                            );
+                            settled_by_grace = true;
+                            settled_by_pending_task_max_wait = true;
                             break;
                         }
                         if saw_valid_stream_event {
@@ -1903,6 +1987,15 @@ impl ClaudeSession {
 
             match parse_claude_stream_json_line(&line) {
                 Ok(event) => {
+                    // Idle-reset the pending Agent/Task max-wait: any successfully parsed stream
+                    // line while a task is pending is evidence the process is alive and working,
+                    // not stalled. This is what makes CLAUDE_BG_TASK_MAX_WAIT an idle bound rather
+                    // than an absolute one; see that constant's doc comment and
+                    // pending_agent_task_deadline's doc comment for why an absolute bound would
+                    // wrongly kill a legitimately long-running background subagent.
+                    if result_seen_at.is_none() && !pending_agent_task_ids.is_empty() {
+                        pending_agent_task_deadline = Some(Instant::now() + CLAUDE_BG_TASK_MAX_WAIT);
+                    }
                     // Structured background-task settlement blockers (issue #983).
                     if let Some(bg_id) = extract_background_task_id(&event) {
                         let before_len = active_background_task_ids.len();
@@ -1926,6 +2019,35 @@ impl ClaudeSession {
                                 turn_id,
                                 bg_id.len()
                             );
+                        }
+                    }
+                    // Agent/Task pending-task tracking (this change): independent of
+                    // active_background_task_ids, only bounds the pre-result wait. Only register
+                    // while result hasn't been seen yet; this matches the observed CLI ordering
+                    // (task_started always arrives before result for this call shape) and keeps
+                    // this from doing anything once the post-result path takes over.
+                    if result_seen_at.is_none() {
+                        if let Some(agent_task_id) = extract_task_started_id(&event) {
+                            let before_len = pending_agent_task_ids.len();
+                            if try_register_background_task_id(
+                                &mut pending_agent_task_ids,
+                                &agent_task_id,
+                            ) {
+                                if before_len != pending_agent_task_ids.len() {
+                                    log::info!(
+                                        "[claude] registered pending Agent/Task turn={} id={} pending={}",
+                                        turn_id,
+                                        agent_task_id,
+                                        pending_agent_task_ids.len()
+                                    );
+                                }
+                            } else if before_len >= stream_helpers::CLAUDE_BG_TASK_SET_MAX {
+                                log::warn!(
+                                    "[claude] pending Agent/Task budget full turn={} rejected_id_len={}",
+                                    turn_id,
+                                    agent_task_id.len()
+                                );
+                            }
                         }
                     }
                     if let Some(release_id) = extract_terminal_task_release_id(&event) {
@@ -1954,6 +2076,25 @@ impl ClaudeSession {
                                     "[claude] re-armed post-result grace after blockers cleared turn={}",
                                     turn_id
                                 );
+                            }
+                        }
+                        // Same release id space, independent set: also try clearing a pending
+                        // Agent/Task entry. A no-op if this id was never in this set.
+                        if try_release_background_task_id(
+                            &mut pending_agent_task_ids,
+                            &release_id,
+                            "completed",
+                        ) {
+                            log::info!(
+                                "[claude] released pending Agent/Task turn={} id={} pending={}",
+                                turn_id,
+                                release_id,
+                                pending_agent_task_ids.len()
+                            );
+                            if pending_agent_task_ids.is_empty() {
+                                // Clear so a later, still-pre-result task_started re-arms its own
+                                // fresh deadline instead of inheriting a stale one.
+                                pending_agent_task_deadline = None;
                             }
                         }
                     }
@@ -2340,6 +2481,16 @@ impl ClaudeSession {
             self.emit_pending_ask_user_question_resume_failure(turn_id, &error_msg);
             self.clear_turn_ephemeral_state(turn_id);
             return Err(error_msg);
+        }
+
+        // A pending-task idle max-wait force-kill must never look identical to an ordinary
+        // empty-but-successful turn; surface it without clobbering any real partial content the
+        // stream already produced before the subagent went silent.
+        if settled_by_pending_task_max_wait && response_text.trim().is_empty() {
+            response_text = format!(
+                "[A background subagent did not report back within {:?} and was abandoned. Its work may be incomplete or lost.]",
+                CLAUDE_BG_TASK_MAX_WAIT
+            );
         }
 
         // Emit turn completed

--- a/src-tauri/src/engine/claude/tests_stream.rs
+++ b/src-tauri/src/engine/claude/tests_stream.rs
@@ -1249,6 +1249,228 @@ async fn send_message_releases_background_blocker_on_matching_terminal_notificat
     );
 }
 
+/// The real, reachable gap `fix-claude-agent-pending-task-unbounded-wait` closes: a backgrounded
+/// Agent/Task subagent (`task_started`) that never emits a terminal `task_notification`, and per
+/// the CLI's observed behavior, never emits `result` either, since it defers `result` until every
+/// pending background task settles (probe evidence in this change's design.md Context). Before
+/// this change, the pre-result wait was completely unbounded; this must now force-settle at
+/// CLAUDE_BG_TASK_MAX_WAIT (3s in test mode) instead of hanging on the 30s sleep below forever.
+#[cfg(unix)]
+#[tokio::test]
+async fn send_message_force_settles_pending_agent_task_that_never_notifies() {
+    let script_body = concat!(
+        "#!/bin/sh\n",
+        "echo '{\"type\":\"system\",\"subtype\":\"task_started\",\"task_id\":\"agent-hang-1\",\"tool_use_id\":\"toolu_1\"}'\n",
+        "# Never emit a task_notification or a result, simulates a crashed/hung subagent.\n",
+        "sleep 30\n",
+        "exit 0\n",
+    );
+    let (root, workspace_path, script_path) = create_fake_claude_script(script_body);
+    let session = test_session_with_bin(workspace_path, script_path);
+    let mut receiver = session.subscribe();
+    let mut params = SendMessageParams::default();
+    params.text = "launch a background agent".to_string();
+
+    let started = std::time::Instant::now();
+    let response = tokio::time::timeout(
+        std::time::Duration::from_secs(20),
+        session.send_message(params, "turn-pending-hang"),
+    )
+    .await
+    .expect("send_message must force-settle at the pending-task max-wait, not hang on the 30s sleep")
+    .expect("a force-settled pending task is a success (result was never expected to arrive)");
+    let elapsed = started.elapsed();
+
+    let events = drain_turn_events(&mut receiver);
+    let _ = std::fs::remove_dir_all(&root);
+
+    assert!(
+        response.contains("did not report back") && response.contains("abandoned"),
+        "abandonment must be a visible notice, never silent empty-success; got {response:?}"
+    );
+    assert!(
+        elapsed >= std::time::Duration::from_secs(2) && elapsed < std::time::Duration::from_secs(10),
+        "expected force-settle around the 3s test CLAUDE_BG_TASK_MAX_WAIT, not the 30s sleep; elapsed={elapsed:?}"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event.event, EngineEvent::TurnCompleted { .. }))
+            .count(),
+        1,
+        "exactly one TurnCompleted after the pending-task max-wait force-settles the turn"
+    );
+}
+
+/// CLAUDE_BG_TASK_MAX_WAIT is an IDLE bound, not an absolute one: a subagent that keeps producing
+/// genuine activity must survive well past the raw 3s test constant, because every received line
+/// resets the deadline. Emits an activity line every 1.5s (under the 3s window) for three rounds,
+/// 4.5s total and already past the raw constant, before settling normally. A regression to an
+/// absolute bound would force-kill this around t=3s instead.
+#[cfg(unix)]
+#[tokio::test]
+async fn send_message_pending_agent_task_idle_reset_survives_past_raw_max_wait() {
+    let script_body = concat!(
+        "#!/bin/sh\n",
+        "echo '{\"type\":\"system\",\"subtype\":\"task_started\",\"task_id\":\"agent-active-1\",\"tool_use_id\":\"toolu_1\"}'\n",
+        "sleep 1.5\n",
+        "echo '{\"type\":\"system\",\"subtype\":\"task_progress\",\"task_id\":\"agent-active-1\"}'\n",
+        "sleep 1.5\n",
+        "echo '{\"type\":\"system\",\"subtype\":\"task_progress\",\"task_id\":\"agent-active-1\"}'\n",
+        "sleep 1.5\n",
+        "echo '{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"<task-notification><task-id>agent-active-1</task-id><status>completed</status><result>done</result></task-notification>\"}]}}'\n",
+        "echo '{\"type\":\"result\",\"session_id\":\"11111111-1111-4111-8111-111111111111\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"final answer\"}]}}'\n",
+        "exit 0\n",
+    );
+    let (root, workspace_path, script_path) = create_fake_claude_script(script_body);
+    let session = test_session_with_bin(workspace_path, script_path);
+    let mut receiver = session.subscribe();
+    let mut params = SendMessageParams::default();
+    params.text = "launch a background agent that keeps working".to_string();
+
+    let started = std::time::Instant::now();
+    let response = tokio::time::timeout(
+        std::time::Duration::from_secs(20),
+        session.send_message(params, "turn-pending-idle-reset"),
+    )
+    .await
+    .expect("send_message must not hang past the outer test timeout")
+    .expect("a genuinely active pending task must settle normally, not be force-killed");
+    let elapsed = started.elapsed();
+
+    let events = drain_turn_events(&mut receiver);
+    let _ = std::fs::remove_dir_all(&root);
+
+    // The assistant text (the notification's own content) arrives before `result` here,
+    // matching the real observed CLI ordering (task_started -> task_notification -> result) -
+    // so `saw_text_delta` is already true by the time `result` is seen and its text is never
+    // separately synthesized (existing, pre-existing behavior, not something this change
+    // touches). What actually matters for this test is that the turn settled as a genuine
+    // success and was NOT abandoned - assert on that, not on which exact event's text won.
+    assert!(
+        !response.contains("did not report back") && !response.is_empty(),
+        "an actively-progressing subagent must complete normally, not be abandoned; got {response:?}"
+    );
+    assert!(
+        elapsed >= std::time::Duration::from_millis(4000),
+        "expected the full ~4.5s activity sequence to complete, proving the idle-reset kept the \
+         bound from firing at the raw 3s constant; elapsed={elapsed:?}"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event.event, EngineEvent::TurnCompleted { .. }))
+            .count(),
+        1
+    );
+}
+
+/// A pending Agent/Task subagent that settles normally (terminal `task_notification` arrives
+/// before `result`, matching the CLI's observed real ordering) must NOT be affected by the new
+/// max-wait bound at all, the turn should complete essentially immediately, not wait anywhere
+/// near CLAUDE_BG_TASK_MAX_WAIT.
+#[cfg(unix)]
+#[tokio::test]
+async fn send_message_pending_agent_task_settles_normally_before_result() {
+    let script_body = concat!(
+        "#!/bin/sh\n",
+        "echo '{\"type\":\"system\",\"subtype\":\"task_started\",\"task_id\":\"agent-notify-1\",\"tool_use_id\":\"toolu_1\"}'\n",
+        "echo '{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"<task-notification><task-id>agent-notify-1</task-id><status>completed</status><result>done</result></task-notification>\"}]}}'\n",
+        "echo '{\"type\":\"result\",\"session_id\":\"11111111-1111-4111-8111-111111111111\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"final answer\"}]}}'\n",
+        "exit 0\n",
+    );
+    let (root, workspace_path, script_path) = create_fake_claude_script(script_body);
+    let session = test_session_with_bin(workspace_path, script_path);
+    let mut receiver = session.subscribe();
+    let mut params = SendMessageParams::default();
+    params.text = "launch a background agent".to_string();
+
+    let started = std::time::Instant::now();
+    let response = tokio::time::timeout(
+        std::time::Duration::from_secs(20),
+        session.send_message(params, "turn-pending-settle"),
+    )
+    .await
+    .expect("send_message must not hang when the pending task settles before result")
+    .expect("normal settlement before result should succeed");
+    let elapsed = started.elapsed();
+
+    let events = drain_turn_events(&mut receiver);
+    let _ = std::fs::remove_dir_all(&root);
+
+    // Same ordering note as the idle-reset test above: the notification's own assistant text
+    // arrives before `result`, so that text - not `result`'s separate "final answer" - is what
+    // ends up as the response (existing, pre-existing synthesize-only-if-no-delta-seen
+    // behavior). What this test actually verifies is settlement without abandonment.
+    assert!(
+        !response.contains("did not report back") && !response.is_empty(),
+        "settlement before result should succeed, not be abandoned; got {response:?}"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "should settle almost immediately, not wait toward CLAUDE_BG_TASK_MAX_WAIT; elapsed={elapsed:?}"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event.event, EngineEvent::TurnCompleted { .. }))
+            .count(),
+        1
+    );
+}
+
+/// A normal turn with no `task_started` at all must be completely unaffected by
+/// CLAUDE_BG_TASK_MAX_WAIT (3s in test mode): the pre-result wait must remain unbounded for a
+/// legitimate turn that simply takes a while, with no risk indicator present.
+#[cfg(unix)]
+#[tokio::test]
+async fn send_message_unaffected_turn_survives_past_pending_task_max_wait() {
+    let script_body = concat!(
+        "#!/bin/sh\n",
+        // A leading valid event (not an assistant text delta - that would trigger the
+        // pre-existing synthesize-only-if-no-delta-seen behavior exercised by the two tests
+        // above, which is not what this test is about) so the long sleep below exercises the
+        // genuinely-unbounded-once-streaming branch, not the separate first-event timeout.
+        "echo '{\"type\":\"system\",\"subtype\":\"init\"}'\n",
+        // No task_started anywhere in this script - keep going well past the 3s test
+        // CLAUDE_BG_TASK_MAX_WAIT to prove it never armed.
+        "sleep 4\n",
+        "echo '{\"type\":\"result\",\"session_id\":\"11111111-1111-4111-8111-111111111111\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"final answer\"}]}}'\n",
+        "exit 0\n",
+    );
+    let (root, workspace_path, script_path) = create_fake_claude_script(script_body);
+    let session = test_session_with_bin(workspace_path, script_path);
+    let mut receiver = session.subscribe();
+    let mut params = SendMessageParams::default();
+    params.text = "hello".to_string();
+
+    let started = std::time::Instant::now();
+    let response = tokio::time::timeout(
+        std::time::Duration::from_secs(20),
+        session.send_message(params, "turn-no-pending-task"),
+    )
+    .await
+    .expect("send_message must not be force-settled by a bound that was never armed")
+    .expect("a normal long turn with no background task should succeed");
+    let elapsed = started.elapsed();
+
+    let events = drain_turn_events(&mut receiver);
+    let _ = std::fs::remove_dir_all(&root);
+
+    assert_eq!(response, "final answer");
+    assert!(
+        elapsed >= std::time::Duration::from_secs(4),
+        "a normal turn with no task_started must survive past the 3s test max-wait unaffected; elapsed={elapsed:?}"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event.event, EngineEvent::TurnCompleted { .. }))
+            .count(),
+        1
+    );
+}
+
 /// Regression: once Claude emits its final `result`, the turn must settle even
 /// if an MCP child / Stop hook inherits stdout and keeps the pipe open past the
 /// CLI leader's exit. Before the post-result grace was wired into the read loop,

--- a/src-tauri/src/engine/claude_stream_helpers.rs
+++ b/src-tauri/src/engine/claude_stream_helpers.rs
@@ -363,6 +363,30 @@ pub(super) fn extract_background_task_id(event: &Value) -> Option<String> {
         })
 }
 
+/// Extract a Task/Agent async-launch id from a structured `task_started` system event.
+///
+/// This is the pre-result pending-task counterpart to `extract_background_task_id`: Agent/Task
+/// async-launch tool results use a different field shape (`toolUseResult.agentId` /
+/// `toolUseResult.isAsync` / `status: "async_launched"`) that `extract_background_task_id` never
+/// matches, and, unlike Bash background shells, the CLI observably defers this turn's own
+/// `result` event until every pending Agent/Task subagent has settled (probe evidence in
+/// `openspec/changes/fix-claude-agent-pending-task-unbounded-wait/design.md` Context), so a
+/// hung/crashed subagent that never emits a terminal `task_notification` leaves `result_seen_at`
+/// permanently `None` with no bound
+/// on the wait. This reads the `task_started` system event's own `task_id` directly, the same
+/// field the existing `extract_terminal_task_release_id` release path already matches against.
+pub(super) fn extract_task_started_id(event: &Value) -> Option<String> {
+    let is_task_started = event.get("type").and_then(|v| v.as_str()) == Some("system")
+        && event.get("subtype").and_then(|v| v.as_str()) == Some("task_started");
+    if !is_task_started {
+        return None;
+    }
+    event
+        .get("task_id")
+        .and_then(|v| v.as_str())
+        .and_then(normalize_background_task_id)
+}
+
 /// Whether a task-notification status is terminal for blocker release.
 pub(super) fn is_terminal_background_task_status(status: &str) -> bool {
     let lower = status.trim().to_ascii_lowercase();
@@ -584,6 +608,47 @@ mod background_task_settlement_tests {
         let long_id = "x".repeat(CLAUDE_BG_TASK_ID_MAX_LEN + 1);
         let event = json!({ "toolUseResult": { "backgroundTaskId": long_id } });
         assert!(extract_background_task_id(&event).is_none());
+    }
+
+    #[test]
+    fn extract_task_started_id_reads_top_level_task_id() {
+        let event = json!({
+            "type": "system",
+            "subtype": "task_started",
+            "task_id": "agent-1",
+            "tool_use_id": "toolu_1"
+        });
+        assert_eq!(extract_task_started_id(&event).as_deref(), Some("agent-1"));
+    }
+
+    #[test]
+    fn extract_task_started_id_ignores_other_subtypes_and_event_types() {
+        let wrong_subtype = json!({
+            "type": "system",
+            "subtype": "task_updated",
+            "task_id": "agent-1"
+        });
+        assert!(extract_task_started_id(&wrong_subtype).is_none());
+
+        let wrong_type = json!({
+            "type": "assistant",
+            "subtype": "task_started",
+            "task_id": "agent-1"
+        });
+        assert!(extract_task_started_id(&wrong_type).is_none());
+
+        let missing_id = json!({ "type": "system", "subtype": "task_started" });
+        assert!(extract_task_started_id(&missing_id).is_none());
+    }
+
+    #[test]
+    fn extract_task_started_id_rejects_empty_and_overlong() {
+        let empty = json!({ "type": "system", "subtype": "task_started", "task_id": "   " });
+        assert!(extract_task_started_id(&empty).is_none());
+
+        let long_id = "x".repeat(CLAUDE_BG_TASK_ID_MAX_LEN + 1);
+        let overlong = json!({ "type": "system", "subtype": "task_started", "task_id": long_id });
+        assert!(extract_task_started_id(&overlong).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## 摘要

A turn that spawns a background Agent/Task subagent can hang forever. While waiting for that turn's
`result`, the read is a bare `lines.next_line().await` with no timeout. If the subagent dies without
emitting its terminal `task_notification`, the CLI never emits `result` either, so the turn blocks
permanently with the UI stuck in "generating". This bounds that one wait with an idle timeout.
#983's post-result path is untouched.

**How this came up, and what it does not fix.** This started as an investigation into a different
problem: background work going missing between turns. The first diagnosis blamed the post-result
grace-kill, and it was wrong. Three in-app reproductions (112s, 37.5s and 502s) all completed
successfully and were never killed, and a `ps` snapshot showed an identical PID and start time
across 510 seconds. The grace-kill turns out never to arm in this scenario at all: it requires
`result_seen_at.is_some()`, and the CLI defers `result` until every pending background **Agent**
task has settled, so that precondition is never true while one is pending. (Scope matters: that
deferral is specific to Agent/Task subagents. A backgrounded Bash shell is the opposite case, where
`result` fires immediately while the shell is still running, which is exactly why #983 needed a
blocker mechanism at all.) The unbounded pre-result wait
below is what the investigation turned up along the way, and it stands on its own merits. **The
original problem is a separate mechanism that this PR does not touch** - it is a different failure at
a different point in the lifecycle. That investigation has since concluded, and the cause is
host-side: the app ends the CLI process at the end of every turn, and the CLI kills its tracked
background tasks as it shuts down. Detail in #983. It needs its own fix and is not folded in here. Stream-ordering captures and
the full falsification are in the change's `design.md`.

The condition this does fix is real but narrow: it needs the CLI process to stay alive while its
internal task tracking wedges permanently, which is not the same as "the subagent crashed", and it
has not been seen in practice. `interrupt()` and the Stop button already recover such a turn by
hand; what is missing is automatic recovery.

## 变更类型

- [ ] feature
- [x] fix
- [ ] refactor / 结构治理
- [ ] docs
- [ ] chore / CI

## AppShell / Domain 状态（若涉及 `src/app-shell/**` 或 shell domain bag）

Not applicable. This PR touches only `src-tauri/src/engine/**` and `openspec/`. No frontend files
and no shell domain bag are involved.

## 测试

- [x] 相关 unit / vitest - seven new Rust tests. Four fake-stream integration tests in
      `engine/claude/tests_stream.rs`: force-settle when a task never notifies, normal settle before
      `result`, an unaffected long turn with no background task, and an idle-reset case proving the
      bound is idle-based rather than absolute. Three unit tests in `claude_stream_helpers.rs`
      covering `extract_task_started_id` (top-level id, subtype and event-type rejection, empty and
      overlong rejection). The existing #983 Bash-path regressions are unchanged and stay green,
      with `WaitBgTasks` still unbounded.
- [ ] `npm run check:runtime-contracts`（含 app-shell governance）- not run; this diff changes no
      frontend files.
- 其它受影响 gate：`cargo test --lib` on a Linux runner: 2037 passed, 5 failed, with all five
      matching the pre-existing baseline failure set on `main` and zero new failures introduced by
      this branch. `openspec validate fix-claude-agent-pending-task-unbounded-wait --strict
      --no-interactive` passes.

## 风险与回滚

- 风险：the bound could in principle end a turn that would otherwise have completed. It is mitigated
  by being an IDLE bound rather than an absolute one: the deadline resets on every parsed stream line
  while a task is pending, so a subagent still producing activity never trips it however long it runs
  in total. It only engages when the stream is fully silent for the whole `CLAUDE_BG_TASK_MAX_WAIT`
  window. Known limitation: two overlapping pending tasks share one deadline, so a later-arriving
  task can be abandoned earlier than its own full window would allow. When the bound does fire and
  `response_text` would otherwise be empty, a visible notice is written so the turn is never a silent
  empty success.
- 回滚：按 commit / PR revert. The two commits are independent: `20899c63c` is the implementation,
  `11be9d1a1` is openspec docs only.

