### PR TITLE
fix(tests): 修正 assemble_canonical_facts 引用已归档 openspec 示例路径

### DIFF
--- a/src-tauri/tests/assemble_canonical_facts.rs
+++ b/src-tauri/tests/assemble_canonical_facts.rs
@@ -25,10 +25,10 @@ const SESSION: &str = "a2-session";
 fn rust_facts_round_trip_wave0_valid_schema_fixtures() {
     for source in [
         include_str!(
-            "../../openspec/changes/establish-session-foundation-contracts/schemas/examples/valid/turn-committed.json"
+            "../../openspec/changes/archive/2026-08-03-establish-session-foundation-contracts/schemas/examples/valid/turn-committed.json"
         ),
         include_str!(
-            "../../openspec/changes/establish-session-foundation-contracts/schemas/examples/valid/control-fact.json"
+            "../../openspec/changes/archive/2026-08-03-establish-session-foundation-contracts/schemas/examples/valid/control-fact.json"
         ),
     ] {
         let envelope: serde_json::Value = serde_json::from_str(source).expect("fixture json");


### PR DESCRIPTION
## 问题

`cargo test`(任意 filter)在 main 上编译 `assemble_canonical_facts` 集成测试目标时失败:

```
error: couldn't read `tests/../../openspec/changes/establish-session-foundation-contracts/schemas/examples/valid/turn-committed.json`: No such file or directory
```

原因:openspec 提案在 `a8cd3f2f9`(第二波归档 37 个 complete 提案)中移至 `openspec/changes/archive/2026-08-03-establish-session-foundation-contracts/`,该测试仍引用归档前路径。这是大文件拆分主计划所有 Rust 验证命令的前置阻塞。

## 修复

两处 `include_str!` 路径指向归档后实际位置(文件内容未动)。全仓 grep 确认仅此一个文件引用旧路径。

## 验证

- 修复前:`cargo test --test assemble_canonical_facts` 编译失败(2 errors)
- 修复后:`test result: ok. 11 passed; 0 failed`