### PR TITLE
fix(pi): 补齐自定义模型会话目录

### DIFF
--- a/openspec/changes/fix-pi-custom-model-catalog-in-session/design.md
+++ b/openspec/changes/fix-pi-custom-model-catalog-in-session/design.md
@@ -1,0 +1,25 @@
+# Design: fix-pi-custom-model-catalog-in-session
+
+## Decisions
+
+### D1: profile/home single source
+
+新增带 `home_override` 的 Pi detection path。启动轻量检测仍保持 `include_models=false`，
+on-demand catalog 才运行 RPC / list-models / configured merge，避免恢复启动重探开销。
+
+### D2: catalog identity
+
+configured model 使用 `provider/modelId` 作为 `ModelInfo.id` 与 runtime model，friendly
+`name` 放入 description。完整 identity 由现有 `split_provider_model` 拆分，并交给
+`plan_rpc_model_reconcile` / `set_model(provider, modelId)`。
+
+### D3: fallback diagnostic
+
+RPC 成功优先；失败后尝试两段 `--list-models`。全部失败时 generated fallback MAY
+保留，但 MUST 同时合并可解析的 configured models，并返回最终 probe error。
+
+## Verification
+
+- Rust tests 覆盖 requested profile loader 与 resident model reconcile matrix。
+- `rustfmt --check`、`typecheck`、runtime contracts、strict OpenSpec validation。
+- macOS GUI 验证新建/已有 Pi 会话选择 configured model 后正常回复。

--- a/openspec/changes/fix-pi-custom-model-catalog-in-session/proposal.md
+++ b/openspec/changes/fix-pi-custom-model-catalog-in-session/proposal.md
@@ -1,0 +1,20 @@
+# Change: fix-pi-custom-model-catalog-in-session
+
+## Why
+
+设置页已能读取 Pi profile 下的 `models.json`，但会话 `get_engine_models("pi")`
+仍主要依赖 RPC / `pi --list-models` / generated fallback。profile/home 未统一时，
+configured provider/model 会在设置页可见，却无法在会话中选择和使用。
+
+## What Changes
+
+- RPC、`pi --list-models` 与 `models.json` loader 统一使用当前 Pi engine config 的 `home_dir`。
+- 将 configured provider/model 合并进会话 catalog，并以 `provider/modelId` 作为完整 identity。
+- 复用现有 resident reconcile，在下一轮调用 `set_model(provider, modelId)`。
+- CLI catalog 探测失败时保留 configured models，并通过 `EngineStatus.error` 暴露 diagnostic。
+
+## Acceptance
+
+- 新建会话与已有会话均可选择 configured model 并正常完成下一轮发送。
+- model selector 显示完整 `provider/modelId`。
+- macOS GUI 已完成实机验证。

--- a/openspec/changes/fix-pi-custom-model-catalog-in-session/specs/pi-models-json-config/spec.md
+++ b/openspec/changes/fix-pi-custom-model-catalog-in-session/specs/pi-models-json-config/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Configured Pi models MUST enter the session catalog
+
+`get_engine_models("pi")` MUST merge configured provider/models from the current Pi
+profile/home into the session catalog. Each configured entry MUST expose the complete
+`provider/modelId` identity. Selecting it in a new or resident session MUST cause the
+next turn to use `set_model(provider, modelId)`.
+
+RPC, `pi --list-models`, and `models.json` loading MUST use the same profile/home.
+When CLI catalog probing fails, configured models MUST remain selectable and the engine
+status MUST expose a diagnostic instead of silently presenting only generated fallback.
+
+#### Scenario: Configured model is selectable
+
+- **WHEN** the active Pi profile defines `cliproxy/gpt-custom` in `models.json`
+- **THEN** the session model catalog MUST contain `cliproxy/gpt-custom`
+- **AND** selecting it MUST apply `set_model("cliproxy", "gpt-custom")` before the next turn
+
+#### Scenario: CLI probing fails
+
+- **WHEN** RPC and both `pi --list-models` attempts fail
+- **AND** the active profile contains a valid configured model
+- **THEN** the configured model MUST remain in the catalog
+- **AND** the engine status MUST contain the probe diagnostic

--- a/openspec/changes/fix-pi-custom-model-catalog-in-session/tasks.md
+++ b/openspec/changes/fix-pi-custom-model-catalog-in-session/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+- [x] 统一 Pi RPC、`--list-models` 与 `models.json` 的 profile/home。
+- [x] 合并 configured models，保留完整 `provider/modelId` identity。
+- [x] 验证现有 `set_model(provider, modelId)` resident reconcile path。
+- [x] 补 requested profile loader test。
+- [x] 完成 Rust、TypeScript、runtime contract 与 strict OpenSpec validation。
+- [x] macOS GUI 验证新建与已有会话。

--- a/src-tauri/src/engine/commands.rs
+++ b/src-tauri/src/engine/commands.rs
@@ -38,7 +38,9 @@ use super::remote_bridge::{
     call_remote_typed, remote_detect_engines_request, remote_engine_interrupt_request,
     remote_engine_send_message_sync_request,
 };
-use super::status::{detect_grok_status, detect_kimi_status, detect_pi_status, load_opencode_models};
+use super::status::{
+    detect_grok_status, detect_kimi_status, detect_pi_status_with_home, load_opencode_models,
+};
 use super::{
     engine_disabled_diagnostic, engine_enabled_in_settings, EngineConfig, EngineStatus, EngineType,
 };
@@ -1587,11 +1589,14 @@ pub async fn get_engine_models(
         EngineType::Pi => {
             let config = manager.get_engine_config(EngineType::Pi).await;
             let custom_bin = config.as_ref().and_then(|cfg| cfg.bin_path.clone());
+            let home_dir = config.as_ref().and_then(|cfg| cfg.home_dir.clone());
             Ok(resolve_engine_models_cache_first(
                 manager,
                 EngineType::Pi,
                 force_refresh,
-                move || async move { detect_pi_status(custom_bin.as_deref()).await },
+                move || async move {
+                    detect_pi_status_with_home(custom_bin.as_deref(), home_dir.as_deref()).await
+                },
             )
             .await)
         }

--- a/src-tauri/src/engine/manager.rs
+++ b/src-tauri/src/engine/manager.rs
@@ -22,8 +22,7 @@ use super::qoder::QoderSession;
 use super::qoder_provider_profile::{QoderDistributionSettings, QoderProviderLaunchProfile};
 use super::status::{
     detect_all_engines_scoped, detect_claude_status, detect_codex_status, detect_grok_status,
-    detect_kimi_status, detect_opencode_status_with_options, detect_pi_status_with_options,
-    detect_qoder_status_with_options,
+    detect_kimi_status, detect_opencode_status_with_options, detect_qoder_status_with_options,
 };
 use super::status::EngineStatusEventSink;
 use super::{disabled_engine_status, AuthState, EngineConfig, EngineStatus, EngineType};
@@ -354,7 +353,14 @@ impl EngineManager {
             EngineType::OpenCode => detect_opencode_status_with_options(bin, false).await,
             EngineType::Kimi => detect_kimi_status(bin).await,
             EngineType::Grok => detect_grok_status(bin).await,
-            EngineType::Pi => detect_pi_status_with_options(bin, false).await,
+            EngineType::Pi => {
+                crate::engine::status::detect_pi_status_with_options_and_home(
+                    bin,
+                    false,
+                    config.and_then(|item| item.home_dir.as_deref()),
+                )
+                .await
+            }
             EngineType::Qoder => detect_qoder_status_with_options(bin, false).await,
             EngineType::Dsh => {
                 crate::engine::dsh::detect_dsh_status(

--- a/src-tauri/src/engine/pi_models_config.rs
+++ b/src-tauri/src/engine/pi_models_config.rs
@@ -26,6 +26,32 @@ use crate::state::AppState;
 
 use super::EngineType;
 
+/// Read custom provider models for the runtime catalog. Invalid or missing
+/// files fail soft; the CLI probe remains the source of truth for built-ins.
+pub fn load_custom_model_entries(home_override: Option<&str>) -> Vec<(String, Value)> {
+    let path = resolve_pi_models_config_file(home_override);
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    let Ok(root) = validate_models_config_text(&text) else {
+        return Vec::new();
+    };
+    let Some(providers) = root.get("providers").and_then(Value::as_object) else {
+        return Vec::new();
+    };
+    providers
+        .iter()
+        .flat_map(|(provider, value)| {
+            value
+                .get("models")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(|model| Some((provider.clone(), model.clone())))
+        })
+        .collect()
+}
+
 /// Default template offered when models.json is missing or empty.
 /// Frontend pre-fills the editor with this; it is NOT written until the user saves.
 const DEFAULT_TEMPLATE: &str = r#"{
@@ -419,6 +445,29 @@ mod tests {
             r#"{"providers": {"x": {"models": [{"name": "no-id"}]}}}"#
         )
         .is_err());
+    }
+
+    #[test]
+    fn runtime_entries_use_the_requested_profile_home() {
+        let dir = temp_agent_dir("runtime-catalog");
+        std::fs::write(
+            dir.join("models.json"),
+            r#"{
+              "providers": {
+                "cliproxy": {
+                  "models": [
+                    {"id": "gpt-custom", "name": "GPT Custom", "reasoning": true}
+                  ]
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+
+        let entries = load_custom_model_entries(dir.to_str());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, "cliproxy");
+        assert_eq!(entries[0].1["id"], "gpt-custom");
     }
 
     #[tokio::test]

--- a/src-tauri/src/engine/status.rs
+++ b/src-tauri/src/engine/status.rs
@@ -925,6 +925,21 @@ pub async fn detect_pi_status_with_options(
     custom_bin: Option<&str>,
     include_models: bool,
 ) -> EngineStatus {
+    detect_pi_status_with_options_and_home(custom_bin, include_models, None).await
+}
+
+pub async fn detect_pi_status_with_home(
+    custom_bin: Option<&str>,
+    home_override: Option<&str>,
+) -> EngineStatus {
+    detect_pi_status_with_options_and_home(custom_bin, true, home_override).await
+}
+
+pub async fn detect_pi_status_with_options_and_home(
+    custom_bin: Option<&str>,
+    include_models: bool,
+    home_override: Option<&str>,
+) -> EngineStatus {
     let bin_path = resolve_bin_path("pi", custom_bin);
     let bin = bin_path
         .as_ref()
@@ -947,7 +962,10 @@ pub async fn detect_pi_status_with_options(
             installed: true,
             version,
             bin_path: Some(bin.to_string()),
-            home_dir: get_pi_home_dir().map(|p| p.to_string_lossy().to_string()),
+            home_dir: home_override
+                .map(PathBuf::from)
+                .or_else(get_pi_home_dir)
+                .map(|p| p.to_string_lossy().to_string()),
             models: Vec::new(),
             default_model: None,
             features: EngineFeatures::pi(),
@@ -958,13 +976,14 @@ pub async fn detect_pi_status_with_options(
     // （max(version 10s, RPC 10s + list-models 10s 回退)），与 FE on-demand
     // timeout 对齐。未安装时 models 探测 spawn 立即失败，结果被丢弃。
     let version_probe = probe_cli_version(&bin, "pi", path_env.as_ref());
-    let models_probe = get_pi_models(&bin, path_env.as_ref());
+    let home_dir = home_override.map(PathBuf::from).or_else(get_pi_home_dir);
+    let home_dir_str = home_dir.as_ref().map(|p| p.to_string_lossy().to_string());
+    let models_probe = get_pi_models(&bin, path_env.as_ref(), home_dir_str.as_deref());
     let ((installed, version, error), (models, config_diagnostic)) =
         tokio::join!(version_probe, models_probe);
     if !installed {
         return not_installed_status(EngineType::Pi, error);
     }
-    let home_dir = get_pi_home_dir();
     let default_model = models.iter().find(|m| m.default).map(|m| m.id.clone());
     EngineStatus {
         engine_type: EngineType::Pi,
@@ -1509,6 +1528,7 @@ pub(crate) fn parse_pi_models_output(stdout: &str) -> Vec<ModelInfo> {
 async fn run_pi_list_models(
     bin: &str,
     path_env: Option<&String>,
+    home_dir: Option<&str>,
     extra_args: &[&str],
 ) -> Result<Vec<ModelInfo>, String> {
     let mut cmd = crate::backend::app_server::build_command_for_binary(bin);
@@ -1518,6 +1538,9 @@ async fn run_pi_list_models(
     }
     if let Some(path) = path_env {
         cmd.env("PATH", path);
+    }
+    if let Some(home) = home_dir {
+        cmd.env("PI_CODING_AGENT_DIR", home);
     }
     let output = timeout(PI_CATALOG_PROBE_TIMEOUT, cmd.output())
         .await
@@ -1535,36 +1558,92 @@ async fn run_pi_list_models(
     Ok(models)
 }
 
-async fn get_pi_models(bin: &str, path_env: Option<&String>) -> (Vec<ModelInfo>, Option<String>) {
-    let (mut models, config_diagnostic) = probe_pi_models_chain(bin, path_env).await;
-    promote_pi_default_from_settings(&mut models);
+fn merge_pi_custom_models(mut models: Vec<ModelInfo>, home_dir: Option<&str>) -> Vec<ModelInfo> {
+    let mut seen: std::collections::HashSet<String> = models.iter().map(|m| m.id.clone()).collect();
+    for (provider, value) in crate::engine::pi_models_config::load_custom_model_entries(home_dir) {
+        let Some(model_id) = value
+            .get("id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+        else {
+            continue;
+        };
+        let id = pi_model_catalog_id(&provider, model_id);
+        if !seen.insert(id.clone()) {
+            continue;
+        }
+        let configured_name = value
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or(model_id);
+        let mut info = ModelInfo::new(id.clone(), id.clone())
+            .with_description(configured_name)
+            .with_provider(provider)
+            .with_protocol("pi")
+            .with_provenance("config:pi-models.json")
+            .with_source("configured");
+        if value
+            .get("reasoning")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            info = info.with_reasoning(
+                PI_STANDARD_THINKING_LEVELS
+                    .iter()
+                    .map(|v| (*v).to_string())
+                    .collect(),
+                None,
+            );
+        }
+        models.push(info);
+    }
+    if models.iter().all(|m| !m.default) {
+        if let Some(first) = models.first_mut() {
+            first.default = true;
+        }
+    }
+    models
+}
+
+async fn get_pi_models(
+    bin: &str,
+    path_env: Option<&String>,
+    home_dir: Option<&str>,
+) -> (Vec<ModelInfo>, Option<String>) {
+    let (mut models, config_diagnostic) = probe_pi_models_chain(bin, path_env, home_dir).await;
+    promote_pi_default_from_settings(&mut models, home_dir.map(Path::new));
     (models, config_diagnostic)
 }
 
 /// PI catalog 三条取数路径（RPC `get_available_models` → `--list-models` 两跳 →
-/// generated fallback）。default 标记保持 parse 层兜底语义（首条目），由
-/// `promote_pi_default_from_settings` 在汇合点按 settings 修正。
+/// generated fallback）。每条路径都使用同一 profile/home，并在汇合前合并
+/// configured models。
 async fn probe_pi_models_chain(
     bin: &str,
     path_env: Option<&String>,
+    home_dir: Option<&str>,
 ) -> (Vec<ModelInfo>, Option<String>) {
-    match fetch_pi_models_via_rpc(bin, None).await {
-        Ok(models) => return (models, None),
+    match fetch_pi_models_via_rpc(bin, home_dir).await {
+        Ok(models) => return (merge_pi_custom_models(models, home_dir), None),
         Err(error) => {
             log::info!("[pi] catalog rpc unavailable ({error}); falling back to --list-models");
         }
     }
     // 先跳过 extension boot（同 RPC 探测理由，实测 9.3s → 1.0s）；失败再裸
     // 跑一次兜底不识别 --no-extensions 的旧版 pi，两次皆败才落 generated fallback。
-    match run_pi_list_models(bin, path_env, &["--no-extensions"]).await {
-        Ok(models) => return (models, None),
+    match run_pi_list_models(bin, path_env, home_dir, &["--no-extensions"]).await {
+        Ok(models) => return (merge_pi_custom_models(models, home_dir), None),
         Err(error) => {
             log::info!("[pi] --list-models with --no-extensions failed ({error}); retrying bare");
         }
     }
-    match run_pi_list_models(bin, path_env, &[]).await {
-        Ok(models) => (models, None),
-        Err(error) => (get_generated_fallback_models(EngineType::Pi), Some(error)),
+    match run_pi_list_models(bin, path_env, home_dir, &[]).await {
+        Ok(models) => (merge_pi_custom_models(models, home_dir), None),
+        Err(error) => (
+            merge_pi_custom_models(get_generated_fallback_models(EngineType::Pi), home_dir),
+            Some(error),
+        ),
     }
 }
 
@@ -1604,9 +1683,8 @@ fn promote_default_model(models: &mut Vec<ModelInfo>, default_id: &str) -> bool 
 
 /// PI default 解析：settings 候选 id 依次 `{defaultProvider}/{defaultModel}` →
 /// 裸 `{defaultModel}`；全部未命中或 settings 不可用时不动列表。
-fn promote_pi_default_from_settings(models: &mut Vec<ModelInfo>) {
-    let Some((provider, model)) = read_pi_default_model_selection(get_pi_home_dir().as_deref())
-    else {
+fn promote_pi_default_from_settings(models: &mut Vec<ModelInfo>, home_dir: Option<&Path>) {
+    let Some((provider, model)) = read_pi_default_model_selection(home_dir) else {
         return;
     };
     for candidate in pi_default_candidate_ids(provider.as_deref(), &model) {


### PR DESCRIPTION
## 问题

Pi 设置页可以读取当前 profile 下的 models.json，但会话 model catalog 没有可靠接入 configured provider/model，导致设置可见而会话不可选。

## 修改

- RPC、pi --list-models 与 models.json loader 统一使用当前 Pi home_dir
- 将 configured models 合并进 get_engine_models(pi)
- catalog 使用完整 provider/modelId identity
- 复用现有 resident reconcile，在下一轮调用 set_model(provider, modelId)
- CLI catalog 探测失败时保留 configured models并返回 diagnostic
- 保留 0.9.5 新增的轻量 startup detection pipeline

## Engine onboarding matrix

- Engine registry：未变更
- Provider binding/profile home：已核对并统一
- Model catalog：已完成 configured merge
- Session start/resident continuation：复用现有 reconcile path
- Renderer selection：已在新建和已有会话目视验证
- Daemon/runtime topology：未新增转发事件或双路径逻辑

## 验证

- cargo check --manifest-path src-tauri/Cargo.toml --lib
- rustfmt --edition 2021 --check 修改的 Rust 文件
- cargo test 定向测试：requested profile loader、model reconcile matrix
- npm run typecheck
- npm run check:runtime-contracts
- OpenSpec strict validation passed
- macOS GUI：新建会话与已有会话均可选择 configured model 并正常回复

## 平台状态

- macOS：已实机验证
- Windows：未实机验证
