### PR TITLE
fix(window): 修复右侧工具栏空白区域拖拽

### DIFF
--- a/openspec/changes/fix-right-topbar-window-drag-region/design.md
+++ b/openspec/changes/fix-right-topbar-window-drag-region/design.md
@@ -1,0 +1,12 @@
+# Design: fix-right-topbar-window-drag-region
+
+## Decision
+
+直接修复现有 `.right-panel-toolbar` ownership：container 使用
+`data-tauri-drag-region` / `-webkit-app-region: drag`，interactive descendants 使用
+`data-tauri-drag-region="false"`。不增加 overlay，因为 overlay 会引入 pointer hit-test 与跨平台层级风险。
+
+## Verification
+
+- Vitest 验证 toolbar container 是 drag region，Git mode slot 是 no-drag。
+- macOS 与 Windows 人工验证 drag/click matrix。

--- a/openspec/changes/fix-right-topbar-window-drag-region/proposal.md
+++ b/openspec/changes/fix-right-topbar-window-drag-region/proposal.md
@@ -1,0 +1,17 @@
+# Change: fix-right-topbar-window-drag-region
+
+## Why
+
+右侧 panel toolbar 顶部被整体标记为 `no-drag`，导致按钮之间的空白区域无法拖动 desktop window，与左侧和中间 titlebar 行为不一致。
+
+## What Changes
+
+- `.right-panel-toolbar` 成为真实 Tauri drag region。
+- `PanelTabs`、Git mode slot 与具体 buttons 保持 `data-tauri-drag-region="false"`，确保交互不被拖拽吞掉。
+- 增加结构测试，锁定 draggable container 与 interactive child 的边界。
+
+## Acceptance
+
+- macOS 与 Windows 上右侧 toolbar 空白区域可拖动窗口。
+- 文件、Git、刷新、更多等 controls 仍可点击。
+- 不新增固定高度 overlay 或临时遮罩。

--- a/openspec/changes/fix-right-topbar-window-drag-region/specs/windows-titlebar-control-safe-zone/spec.md
+++ b/openspec/changes/fix-right-topbar-window-drag-region/specs/windows-titlebar-control-safe-zone/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Interactive titlebar controls remain clickable
+
+Desktop frameless titlebar regions MUST preserve clickable controls with `no-drag`
+semantics while exposing non-interactive blank space as a window drag region.
+
+#### Scenario: Right panel toolbar blank space drags the window
+
+- **WHEN** the user drags non-interactive blank space in the right panel toolbar
+- **THEN** the desktop window MUST move with the pointer
+- **AND** clicking Files, Git, refresh, or overflow controls MUST still invoke the control

--- a/openspec/changes/fix-right-topbar-window-drag-region/tasks.md
+++ b/openspec/changes/fix-right-topbar-window-drag-region/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] 将 `.right-panel-toolbar` 标记为 Tauri drag region。
+- [x] 保留 toolbar controls 的 no-drag boundary。
+- [x] 增加结构测试。
+- [x] macOS 人工验证拖拽与按钮点击。
+- [ ] Windows 人工验证拖拽与按钮点击。

--- a/src/components/ui/responsive-icon-toolbar.tsx
+++ b/src/components/ui/responsive-icon-toolbar.tsx
@@ -210,7 +210,7 @@ export function ResponsiveIconToolbar({
       className={className}
       role={role}
       aria-label={ariaLabel}
-      data-tauri-drag-region="false"
+      data-tauri-drag-region
     >
       {leadingVisibleItems.map((item) => (
         <TooltipIconButton

--- a/src/features/layout/components/PanelTabs.test.tsx
+++ b/src/features/layout/components/PanelTabs.test.tsx
@@ -32,6 +32,7 @@ describe("PanelTabs", () => {
     const filesButton = screen.getByRole("button", { name: "panels.files" });
     const moreButton = screen.getByRole("button", { name: "common.moreActions" });
 
+    expect(screen.getByRole("tablist").hasAttribute("data-tauri-drag-region")).toBe(true);
     expect(filesButton.getAttribute("data-tauri-drag-region")).toBe("false");
     expect(moreButton.getAttribute("data-tauri-drag-region")).toBe("false");
 

--- a/src/features/layout/hooks/layoutNodeSections.tsx
+++ b/src/features/layout/hooks/layoutNodeSections.tsx
@@ -69,6 +69,7 @@ export function buildRightPanelToolbarNode({
   return (
     <div
       className={`right-panel-toolbar${active === "git" ? " has-git-mode-slot" : ""}`}
+      data-tauri-drag-region
     >
       {active === "git" ? (
         <div

--- a/src/features/layout/hooks/useLayoutNodes.client-ui-visibility.test.tsx
+++ b/src/features/layout/hooks/useLayoutNodes.client-ui-visibility.test.tsx
@@ -1653,6 +1653,8 @@ describe("useLayoutNodes client UI visibility", () => {
 
     expect(target).toBeTruthy();
     expect(toolbar?.classList.contains("has-git-mode-slot")).toBe(true);
+    expect(toolbar?.hasAttribute("data-tauri-drag-region")).toBe(true);
+    expect(target?.getAttribute("data-tauri-drag-region")).toBe("false");
     expect(toolbar?.firstElementChild).toBe(target);
     expect(target?.nextElementSibling?.getAttribute("data-testid")).toBe(
       "panel-tabs",

--- a/src/features/layout/hooks/useWindowDrag.test.tsx
+++ b/src/features/layout/hooks/useWindowDrag.test.tsx
@@ -28,6 +28,7 @@ describe("useWindowDrag", () => {
     document.body.innerHTML = "";
     const titlebar = document.createElement("div");
     titlebar.id = "titlebar";
+    titlebar.setAttribute("data-tauri-drag-region", "");
     document.body.appendChild(titlebar);
 
     mocks.getCurrentWindow.mockReset();
@@ -92,6 +93,54 @@ describe("useWindowDrag", () => {
     await flushMicrotasks();
 
     expect(isFullscreen).toHaveBeenCalledTimes(1);
+    expect(startDragging).not.toHaveBeenCalled();
+  });
+
+  it("starts non-Windows dragging from the right toolbar blank region", async () => {
+    const isFullscreen = vi.fn().mockResolvedValue(false);
+    const startDragging = vi.fn().mockResolvedValue(undefined);
+    mocks.getCurrentWindow.mockReturnValue({ isFullscreen, startDragging });
+    const toolbar = document.createElement("div");
+    toolbar.className = "right-panel-toolbar";
+    toolbar.setAttribute("data-tauri-drag-region", "");
+    document.body.appendChild(toolbar);
+
+    renderHook(() => useWindowDrag("titlebar"));
+    toolbar.dispatchEvent(
+      new MouseEvent("mousedown", {
+        bubbles: true,
+        button: 0,
+        buttons: 1,
+        detail: 1,
+      }),
+    );
+    await flushMicrotasks();
+
+    expect(startDragging).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps right toolbar controls non-draggable", async () => {
+    const isFullscreen = vi.fn().mockResolvedValue(false);
+    const startDragging = vi.fn().mockResolvedValue(undefined);
+    mocks.getCurrentWindow.mockReturnValue({ isFullscreen, startDragging });
+    const toolbar = document.createElement("div");
+    toolbar.setAttribute("data-tauri-drag-region", "");
+    const button = document.createElement("button");
+    button.setAttribute("data-tauri-drag-region", "false");
+    toolbar.appendChild(button);
+    document.body.appendChild(toolbar);
+
+    renderHook(() => useWindowDrag("titlebar"));
+    button.dispatchEvent(
+      new MouseEvent("mousedown", {
+        bubbles: true,
+        button: 0,
+        buttons: 1,
+        detail: 1,
+      }),
+    );
+    await flushMicrotasks();
+
     expect(startDragging).not.toHaveBeenCalled();
   });
 

--- a/src/features/layout/hooks/useWindowDrag.ts
+++ b/src/features/layout/hooks/useWindowDrag.ts
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { isWindowsPlatform } from "../../../utils/platform";
 
-export function useWindowDrag(targetId: string) {
+export function useWindowDrag(_targetId: string) {
   useEffect(() => {
     const isWindowsDesktop = isWindowsPlatform();
 
@@ -33,6 +33,7 @@ export function useWindowDrag(targetId: string) {
             [
               ".main-topbar",
               ".main-header",
+              ".right-panel-toolbar",
               ".sidebar-topbar-placeholder",
               ".sidebar-topbar-content",
             ].join(","),
@@ -177,16 +178,18 @@ export function useWindowDrag(targetId: string) {
       };
     }
 
-    const el = document.getElementById(targetId);
-    if (!el) {
-      return;
-    }
-
     const handler = (event: MouseEvent) => {
       if (event.buttons !== 1) {
         return;
       }
       if (event.detail > 1) {
+        return;
+      }
+      const target = event.target as HTMLElement | null;
+      if (
+        !target?.closest(`[data-tauri-drag-region]:not([data-tauri-drag-region="false"])`) ||
+        target.closest('[data-tauri-drag-region="false"]')
+      ) {
         return;
       }
       void (async () => {
@@ -203,9 +206,9 @@ export function useWindowDrag(targetId: string) {
       })();
     };
 
-    el.addEventListener("mousedown", handler);
+    document.addEventListener("mousedown", handler);
     return () => {
-      el.removeEventListener("mousedown", handler);
+      document.removeEventListener("mousedown", handler);
     };
-  }, [targetId]);
+  }, [_targetId]);
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1995,7 +1995,7 @@ body.editor-horizontal-split-resizing * {
   box-sizing: border-box;
   position: relative;
   z-index: 3;
-  -webkit-app-region: no-drag;
+  -webkit-app-region: drag;
 }
 
 .right-panel-toolbar.has-git-mode-slot {


### PR DESCRIPTION
## 问题

右侧 panel toolbar 的视觉空白实际被 flex: 1 的 panel-tabs 根节点覆盖，且该节点此前属于 no-drag。macOS 非 Windows drag handler 又只监听固定 titlebar，导致右上角空白区域无法拖动窗口。

## 修改

- right-panel-toolbar 与 panel-tabs 空白区域声明为 drag region
- 文件、Git、更多等具体 controls 保持 data-tauri-drag-region=false
- 非 Windows 路径改为委托监听有效 drag region
- Windows intentional movement 判定纳入 right-panel-toolbar
- 不使用固定高度 overlay 或 timeout

## 验证

- PanelTabs tests：15 passed
- useWindowDrag tests：5 passed
- useLayoutNodes client UI visibility tests：31 passed
- 合计 3 files / 51 tests passed
- npm run typecheck
- OpenSpec strict validation passed
- macOS GUI：右上角空白可拖动，文件/Git/更多按钮仍可点击

## 平台状态

- macOS：已实机验证
- Windows：代码路径与自动测试已覆盖，未进行实机验证
