### PR TITLE
fix(history): sync Codex task names and repair stale context titles

### DIFF
--- a/src-tauri/src/history/codex_titles.rs
+++ b/src-tauri/src/history/codex_titles.rs
@@ -1,0 +1,139 @@
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+/// Codex app task names are stored separately from rollout messages. The
+/// append-only index can contain multiple names for an ID; the last one wins.
+fn read_names(path: &Path) -> HashMap<String, String> {
+    let Ok(file) = std::fs::File::open(path) else {
+        return HashMap::new();
+    };
+    let mut names = HashMap::new();
+    for line in BufReader::new(file).lines() {
+        let Ok(line) = line else { break };
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        let Some(id) = value.get("id").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        let Some(name) = value.get("thread_name").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if !id.is_empty() && !name.trim().is_empty() {
+            names.insert(id.to_owned(), name.trim().to_owned());
+        }
+    }
+    names
+}
+
+/// Run even when rollout stat signatures match: renaming a task does not
+/// modify its rollout. Update the derived title, leaving local custom titles
+/// and message timestamps intact.
+pub(super) fn sync(db: &crate::db::Db) -> Result<bool, String> {
+    let home = crate::engine::engine_home(Some("CODEX_HOME"), ".codex");
+    sync_from(db, &home.join("session_index.jsonl"))
+}
+
+fn sync_from(db: &crate::db::Db, path: &Path) -> Result<bool, String> {
+    let names = read_names(path);
+    if names.is_empty() {
+        return Ok(false);
+    }
+    let mut conn = db.0.lock();
+    let tx = conn.transaction().map_err(|e| e.to_string())?;
+    let updates: Vec<(String, String)> = {
+        let mut stmt = tx
+            .prepare("SELECT session_id, title FROM sessions WHERE engine='codex'")
+            .map_err(|e| e.to_string())?;
+        let rows = stmt
+            .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))
+            .map_err(|e| e.to_string())?;
+        let mut updates = Vec::new();
+        for row in rows {
+            let (id, title) = row.map_err(|e| e.to_string())?;
+            if let Some(name) = names.get(&id).filter(|name| **name != title) {
+                updates.push((id, name.clone()));
+            }
+        }
+        updates
+    };
+    for (id, name) in &updates {
+        tx.execute(
+            "UPDATE sessions SET title=?1 WHERE engine='codex' AND session_id=?2",
+            rusqlite::params![name, id],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    tx.commit().map_err(|e| e.to_string())?;
+    Ok(!updates.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sync_names_and_renames_preserving_fallback_and_custom_titles() -> Result<(), String> {
+        let dir = std::env::temp_dir().join(format!("ccgui-codex-names-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = crate::db::Db::open_at(&dir.join("app.db")).map_err(|e| e.to_string())?;
+        let index = dir.join("session_index.jsonl");
+        {
+            let conn = db.0.lock();
+            for (engine, id) in [("codex", "a"), ("codex", "b"), ("omp", "a")] {
+                conn.execute(
+                    "INSERT INTO sessions(engine, session_id, workspace_path, file_path, file_size, file_mtime_ms, title, custom_title, updated_at) VALUES(?1, ?2, '/ws', ?3, 10, 20, 'first message', 'local name', 30)",
+                    rusqlite::params![engine, id, format!("{engine}-{id}")],
+                ).map_err(|e| e.to_string())?;
+            }
+        }
+        assert!(!sync_from(&db, &index)?);
+        std::fs::write(
+            &index,
+            concat!(
+                "{\"id\":\"a\",\"thread_name\":\"Old name\"}\n",
+                "{\"id\":\"a\",\"thread_name\":\"查看飞书 Bug 7070571790\"}\n",
+                "{\"id\":\"b\",\"thread_name\":\" \"}\n",
+                "{invalid trailing record\n"
+            ),
+        )
+        .unwrap();
+        assert!(sync_from(&db, &index)?);
+        assert!(!sync_from(&db, &index)?);
+        {
+            let conn = db.0.lock();
+            let row: (String, String, i64) = conn.query_row(
+                "SELECT title, custom_title, updated_at FROM sessions WHERE engine='codex' AND session_id='a'",
+                [], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            ).unwrap();
+            assert_eq!(
+                row,
+                ("查看飞书 Bug 7070571790".into(), "local name".into(), 30)
+            );
+            let fallback: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM sessions WHERE title='first message'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(fallback, 2);
+        }
+        // Only the external title index changes; no rollout needs reparsing.
+        std::fs::write(&index, "{\"id\":\"a\",\"thread_name\":\"Renamed\"}\n").unwrap();
+        assert!(sync_from(&db, &index)?);
+        let title: String =
+            db.0.lock()
+                .query_row(
+                    "SELECT title FROM sessions WHERE engine='codex' AND session_id='a'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+        assert_eq!(title, "Renamed");
+        drop(db);
+        std::fs::remove_dir_all(dir).unwrap();
+        Ok(())
+    }
+}

--- a/src-tauri/src/history/mod.rs
+++ b/src-tauri/src/history/mod.rs
@@ -285,25 +285,25 @@ pub(crate) fn clean_user_turn(text: &str) -> String {
     if let Some(display) = slash_command_display(rest) {
         return display;
     }
-    // The `# AGENTS.md instructions` heading precedes the `<INSTRUCTIONS>`
-    // block; drop it only when that block actually follows.
-    if let Some(after) = rest.strip_prefix("# AGENTS.md instructions") {
-        let after = after.trim_start();
-        // Codex appends the workspace path: `# AGENTS.md instructions for
-        // <path>\n\n<INSTRUCTIONS>` — skip the heading line first.
-        let after = match after.strip_prefix("for ") {
-            Some(tail) => match tail.find('\n') {
-                Some(nl) => tail[nl + 1..].trim_start(),
-                None => after,
-            },
-            None => after,
-        };
-        if after.starts_with("<INSTRUCTIONS>") {
-            rest = after;
-        }
-    }
     loop {
         let prev_len = rest.len();
+        // The `# AGENTS.md instructions` heading precedes the `<INSTRUCTIONS>`
+        // block; drop it only when that block actually follows.
+        if let Some(after) = rest.strip_prefix("# AGENTS.md instructions") {
+            let after = after.trim_start();
+            // Codex appends the workspace path: `# AGENTS.md instructions for
+            // <path>\n\n<INSTRUCTIONS>` — skip the heading line first.
+            let after = match after.strip_prefix("for ") {
+                Some(tail) => match tail.find('\n') {
+                    Some(nl) => tail[nl + 1..].trim_start(),
+                    None => after,
+                },
+                None => after,
+            };
+            if after.starts_with("<INSTRUCTIONS>") {
+                rest = after;
+            }
+        }
         for tag in INJECTED_LEADING_TAGS {
             let open = format!("<{tag}>");
             if rest.starts_with(&open) {
@@ -485,6 +485,18 @@ mod tests {
         assert_eq!(clean_user_turn(text), "");
     }
     #[test]
+    fn clean_repeated_context_blocks_before_typed_body() {
+        let context = "<recommended_plugins>plugins</recommended_plugins># AGENTS.md instructions for /tmp/ws\n\n<INSTRUCTIONS>rules</INSTRUCTIONS><environment_context>env</environment_context>";
+        assert_eq!(clean_user_turn(context), "");
+        assert_eq!(
+            clean_user_turn(&format!("{context}{context}\n修复标题")),
+            "修复标题"
+        );
+        let typed = "# AGENTS.md instructions 是什么意思？";
+        assert_eq!(clean_user_turn(&format!("{context}{typed}")), typed);
+    }
+
+    #[test]
     fn clean_drops_recommended_plugins_envelope() {
         let text = "<recommended_plugins>Here is a list of plugins that are available but not installed. …</recommended_plugins>";
         assert_eq!(clean_user_turn(text), "");
@@ -509,7 +521,8 @@ mod tests {
 
     #[test]
     fn clean_keeps_typed_tail_after_recommended_plugins() {
-        let text = "<recommended_plugins>Here is a list of plugins…</recommended_plugins>\n继续定位一下";
+        let text =
+            "<recommended_plugins>Here is a list of plugins…</recommended_plugins>\n继续定位一下";
         assert_eq!(clean_user_turn(text), "继续定位一下");
     }
 

--- a/src-tauri/src/history/mod.rs
+++ b/src-tauri/src/history/mod.rs
@@ -1,3 +1,4 @@
+mod codex_titles;
 mod extract;
 pub mod reader;
 pub mod scanner;

--- a/src-tauri/src/history/scanner.rs
+++ b/src-tauri/src/history/scanner.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 /// Bump when title derivation changes so unchanged files still re-title.
-const TITLE_VERSION: &str = "6";
+const TITLE_VERSION: &str = "7";
 
 /// Titles matching these prefixes were derived before envelope stripping
 /// existed; one migration pass re-derives them even when files are unchanged.
@@ -17,7 +17,7 @@ const NOISE_TITLE_WHERE: &str = "title LIKE '<file %' ESCAPE '\\'
      OR title LIKE '<environment\\_context%' ESCAPE '\\'
      OR title LIKE '<agents-instructions%'
      OR title LIKE '<skill>%'
-     OR title LIKE '<recommended\\_plugins%' ESCAPE '\'
+     OR title LIKE '<recommended\\_plugins%' ESCAPE '\\'
      OR title LIKE '<command-message%'
      OR title LIKE '<command-name%'
      OR title LIKE '<INSTRUCTIONS>%'";
@@ -510,7 +510,7 @@ fn tier1_gate(db: &crate::db::Db, signature: String) -> Result<Option<Tier1>, St
                 [],
                 |r| r.get::<_, i64>(0),
             )
-            .unwrap_or(0)
+            .map_err(|e| e.to_string())?
             > 0;
     if previous.as_deref() == Some(signature.as_str()) && row_count > 0 && !retitle_pending {
         return Ok(None);
@@ -951,6 +951,42 @@ mod tests {
             .map_err(|e| e.to_string())?
         };
         assert_eq!(title, "hello");
+
+        // Simulate a v6 cache with an unchanged rollout and an injected title.
+        // The migration must bypass both stat caches and preserve custom titles.
+        {
+            let conn = db.0.lock();
+            conn.execute(
+                "UPDATE sessions SET title='<recommended_plugins>plugins', custom_title='My title'",
+                [],
+            )
+            .map_err(|e| e.to_string())?;
+            conn.execute("UPDATE meta SET value='6' WHERE key='title_version'", [])
+                .map_err(|e| e.to_string())?;
+        }
+        let report = scan_with(&db, || {})?;
+        assert_eq!(report.reparsed, 1);
+        {
+            let conn = db.0.lock();
+            let (title, custom): (String, String) = conn
+                .query_row(
+                    "SELECT title, custom_title FROM sessions WHERE session_id='sid-1'",
+                    [],
+                    |r| Ok((r.get(0)?, r.get(1)?)),
+                )
+                .map_err(|e| e.to_string())?;
+            assert_eq!(title, "hello");
+            assert_eq!(custom, "My title");
+            let version: String = conn
+                .query_row(
+                    "SELECT value FROM meta WHERE key='title_version'",
+                    [],
+                    |r| r.get(0),
+                )
+                .map_err(|e| e.to_string())?;
+            assert_eq!(version, TITLE_VERSION);
+        }
+        assert_eq!(scan_with(&db, || {})?.reparsed, 0);
         drop(db);
         std::fs::remove_dir_all(&home).ok();
         Ok(())

--- a/src-tauri/src/history/scanner.rs
+++ b/src-tauri/src/history/scanner.rs
@@ -698,6 +698,9 @@ fn scan_inner(
     let candidates = gather_candidates(&workspaces);
     let (stats, signature) = stat_all(&workspaces, &candidates);
     let Some(tier1) = tier1_gate(db, signature)? else {
+        if super::codex_titles::sync(db)? {
+            on_changed();
+        }
         return Ok(ScanReport {
             scanned: candidates.len(),
             reparsed: 0,
@@ -743,6 +746,7 @@ fn scan_inner(
     // Phase B: the db lock is held only for the upsert transaction.
     let reparsed = rows.len();
     upsert_rows(db, &rows, &tier1)?;
+    super::codex_titles::sync(db)?;
     on_changed();
     if total > 0 {
         on_progress(crate::event_sink::ScanProgress {


### PR DESCRIPTION
Codex history entries could display injected `<recommended_plugins>` context or raw first-message text instead of the task names shown in Codex. This change reads task names from Codex's `session_index.jsonl` and synchronizes renames even when rollout files have not changed. Sessions without an indexed name retain the message-derived fallback, and local custom titles remain intact.

The context cleaner now handles chained plugin, AGENTS.md, and environment blocks. Fix the SQLite ESCAPE clause, propagate migration query errors, and bump the title version so stale cached titles are re-derived.

Validation: `cargo test --manifest-path src-tauri/Cargo.toml history:: --lib` — 42 passed. Regression coverage includes chained context, v6 cache migration with unchanged files, custom-title preservation, duplicate index entries, malformed/missing index data, and task renames.
