### PR TITLE
fix: 文件链接百分号解码、omp 停止聚合杀与报错透出、思考过程交互优化

### DIFF
--- a/.github/workflows/build-windows-artifact.yml
+++ b/.github/workflows/build-windows-artifact.yml
@@ -1,0 +1,47 @@
+name: Build Windows artifact
+
+on: [push]
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.29.3
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Rust tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml --lib
+
+      - name: Disable updater signing for artifact build
+        shell: pwsh
+        run: |
+          $path = "src-tauri/tauri.conf.json"
+          $config = Get-Content $path -Raw | ConvertFrom-Json
+          $config.bundle.createUpdaterArtifacts = $false
+          $config | ConvertTo-Json -Depth 20 | Set-Content $path
+
+      - name: Build unsigned Windows installer
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+        run: pnpm exec tauri build --config src-tauri/tauri.windows.conf.json --bundles nsis --no-sign
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ccgui-windows-x64
+          path: |
+            src-tauri/target/release/ccgui-next.exe
+            src-tauri/target/release/bundle/nsis/*.exe
+          if-no-files-found: error

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "dev": "tauri dev"
   },
   "dependencies": {
+    "@codemirror/language": "6.12.3",
     "@codemirror/language-data": "^6.5.2",
+    "@codemirror/state": "6.7.2",
+    "@codemirror/view": "6.43.10",
     "@fontsource-variable/inter": "^5.2.0",
     "@fontsource-variable/jetbrains-mono": "^5.2.0",
     "@lobehub/icons-static-svg": "^1.95.0",
@@ -40,6 +43,7 @@
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4",
     "tailwind-merge": "^3.6.0",
+    "unified": "11.0.5",
     "zustand": "^5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,9 +13,18 @@ importers:
 
   .:
     dependencies:
+      '@codemirror/language':
+        specifier: 6.12.3
+        version: 6.12.3
       '@codemirror/language-data':
         specifier: ^6.5.2
         version: 6.5.2
+      '@codemirror/state':
+        specifier: 6.7.2
+        version: 6.7.2
+      '@codemirror/view':
+        specifier: 6.43.10
+        version: 6.43.10
       '@fontsource-variable/inter':
         specifier: ^5.2.0
         version: 5.3.0
@@ -42,7 +51,7 @@ importers:
         version: 2.11.0
       '@uiw/react-codemirror':
         specifier: ^4
-        version: 4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.11)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.2)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.10)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
@@ -97,6 +106,9 @@ importers:
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
+      unified:
+        specifier: 11.0.5
+        version: 11.0.5
       zustand:
         specifier: ^5
         version: 5.0.15(@types/react@18.3.31)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -297,8 +309,8 @@ packages:
   '@codemirror/language-data@6.5.2':
     resolution: {integrity: sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==}
 
-  '@codemirror/language@6.12.4':
-    resolution: {integrity: sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==}
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
 
   '@codemirror/legacy-modes@6.5.4':
     resolution: {integrity: sha512-/cZr6qZyl08iYNLGsJ862CXXNI51LryRFRE40ejgoIjXZz0C1rGkD3/Ek5jM/8w1ceRjqtt4qx/KLMh4zBTgew==}
@@ -309,14 +321,14 @@ packages:
   '@codemirror/search@6.7.2':
     resolution: {integrity: sha512-gUYkYhT2+n/+VGZ+8EzE5WFkYZUZYm1VOKDudIsNqh42uRVQJ0a6Yss9sdKT3MeOYfuL1N6AZA57oza0Oyr0LA==}
 
-  '@codemirror/state@6.7.4':
-    resolution: {integrity: sha512-QhQIVRY+xHZDxwOSFrJ1eUMapJBUID3IdeAjf7dHO7zBUzSkyooHiodnalz5MG3iHzwixKMlAAyn7244y537EA==}
+  '@codemirror/state@6.7.2':
+    resolution: {integrity: sha512-U3RiPX62Wl/Gx4ftQ7UxLlloSfsFTQqKa+7vFBYteZGCzkp6oBqcsD7iSwniWRGobCAmDcwZSY+Six3+3ztdfg==}
 
   '@codemirror/theme-one-dark@6.1.3':
     resolution: {integrity: sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==}
 
-  '@codemirror/view@6.43.11':
-    resolution: {integrity: sha512-2+esucbQX6wB2JYi1eDvdCPFTA31BN8oSy6xCmk3G6CloV11yOvEjYk+gH7kLrP0MuHG94E8WDhjs5oMiu3+Wg==}
+  '@codemirror/view@6.43.10':
+    resolution: {integrity: sha512-vVWLvd4fKWYN/pMcwUrg6dWeublxmSz+V+52ZjW3h64IVN9cRUYLk5Km4JDT9vifxAFfDtNOIFxKYENthcolJQ==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -1912,45 +1924,45 @@ snapshots:
 
   '@codemirror/autocomplete@6.20.3':
     dependencies:
-      '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.4
-      '@codemirror/view': 6.43.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
       '@lezer/common': 1.5.2
 
   '@codemirror/commands@6.11.0':
     dependencies:
-      '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.4
-      '@codemirror/view': 6.43.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
       '@lezer/common': 1.5.2
 
   '@codemirror/lang-angular@0.1.4':
     dependencies:
       '@codemirror/lang-html': 6.4.12
       '@codemirror/lang-javascript': 6.2.5
-      '@codemirror/language': 6.12.4
+      '@codemirror/language': 6.12.3
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
 
   '@codemirror/lang-cpp@6.0.3':
     dependencies:
-      '@codemirror/language': 6.12.4
+      '@codemirror/language': 6.12.3
       '@lezer/cpp': 1.1.6
 
   '@codemirror/lang-css@6.3.1':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
-      '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.4
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.7.2
       '@lezer/common': 1.5.2
       '@lezer/css': 1.3.6
 
   '@codemirror/lang-go@6.0.1':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
-      '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.4
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.7.2
       '@lezer/common': 1.5.2
       '@lezer/go': 1.0.1
 
@@ -1959,25 +1971,25 @@ snapshots:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/lang-css': 6.3.1
       '@codemirror/lang-javascript': 6.2.5
-      '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.4
-      '@codemirror/view': 6.43.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
       '@lezer/common': 1.5.2
       '@lezer/css': 1.3.6
       '@lezer/html': 1.3.13
 
   '@codemirror/lang-java@6.0.2':
     dependencies:
-      '@codemirror/language': 6.12.4
+      '@codemirror/language': 6.12.3
       '@lezer/java': 1.1.3
 
   '@codemirror/lang-javascript@6.2.5':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
-      '@codemirror/language': 6.12.4
+      '@codemirror/language': 6.12.3
       '@codemirror/lint': 6.9.7
-      '@codemirror/state': 6.7.4
-      '@codemirror/view': 6.43.11
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
       '@lezer/common': 1.5.2
       '@lezer/javascript': 1.5.4
 
@@ -1985,22 +1997,22 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/lang-html': 6.4.12
-      '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.4
-      '@codemirror/view': 6.43.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
 
   '@codemirror/lang-json@6.0.2':
     dependencies:
-      '@codemirror/language': 6.12.4
+      '@codemirror/language': 6.12.3
       '@lezer/json': 1.0.3
 
   '@codemirror/lang-less@6.0.2':
     dependencies:
       '@codemirror/lang-css': 6.3.1
-      '@codemirror/language': 6.12.4
+      '@codemirror/language': 6.12.3
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -2009,9 +2021,9 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/lang-html': 6.4.12
-      '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.4
-      '@codemirror/view': 6.43.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -2020,46 +2032,46 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/lang-html': 6.4.12
-      '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.4
-      '@codemirror/view': 6.43.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
       '@lezer/common': 1.5.2
       '@lezer/markdown': 1.7.2
 
   '@codemirror/lang-php@6.0.2':
     dependencies:
       '@codemirror/lang-html': 6.4.12
-      '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.4
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.7.2
       '@lezer/common': 1.5.2
       '@lezer/php': 1.0.6
 
   '@codemirror/lang-python@6.2.1':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
-      '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.4
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.7.2
       '@lezer/common': 1.5.2
       '@lezer/python': 1.1.19
 
   '@codemirror/lang-rust@6.0.2':
     dependencies:
-      '@codemirror/language': 6.12.4
+      '@codemirror/language': 6.12.3
       '@lezer/rust': 1.0.2
 
   '@codemirror/lang-sass@6.0.2':
     dependencies:
       '@codemirror/lang-css': 6.3.1
-      '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.4
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.7.2
       '@lezer/common': 1.5.2
       '@lezer/sass': 1.1.0
 
   '@codemirror/lang-sql@6.10.0':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
-      '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.4
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.7.2
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -2068,14 +2080,14 @@ snapshots:
     dependencies:
       '@codemirror/lang-html': 6.4.12
       '@codemirror/lang-javascript': 6.2.5
-      '@codemirror/language': 6.12.4
+      '@codemirror/language': 6.12.3
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
 
   '@codemirror/lang-wast@6.0.2':
     dependencies:
-      '@codemirror/language': 6.12.4
+      '@codemirror/language': 6.12.3
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -2083,17 +2095,17 @@ snapshots:
   '@codemirror/lang-xml@6.1.0':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
-      '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.4
-      '@codemirror/view': 6.43.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
       '@lezer/common': 1.5.2
       '@lezer/xml': 1.0.6
 
   '@codemirror/lang-yaml@6.1.3':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
-      '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.4
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.7.2
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -2122,13 +2134,13 @@ snapshots:
       '@codemirror/lang-wast': 6.0.2
       '@codemirror/lang-xml': 6.1.0
       '@codemirror/lang-yaml': 6.1.3
-      '@codemirror/language': 6.12.4
+      '@codemirror/language': 6.12.3
       '@codemirror/legacy-modes': 6.5.4
 
-  '@codemirror/language@6.12.4':
+  '@codemirror/language@6.12.3':
     dependencies:
-      '@codemirror/state': 6.7.4
-      '@codemirror/view': 6.43.11
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -2136,34 +2148,34 @@ snapshots:
 
   '@codemirror/legacy-modes@6.5.4':
     dependencies:
-      '@codemirror/language': 6.12.4
+      '@codemirror/language': 6.12.3
 
   '@codemirror/lint@6.9.7':
     dependencies:
-      '@codemirror/state': 6.7.4
-      '@codemirror/view': 6.43.11
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
       crelt: 1.0.7
 
   '@codemirror/search@6.7.2':
     dependencies:
-      '@codemirror/state': 6.7.4
-      '@codemirror/view': 6.43.11
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
       crelt: 1.0.7
 
-  '@codemirror/state@6.7.4':
+  '@codemirror/state@6.7.2':
     dependencies:
       '@marijn/find-cluster-break': 1.0.4
 
   '@codemirror/theme-one-dark@6.1.3':
     dependencies:
-      '@codemirror/language': 6.12.4
-      '@codemirror/state': 6.7.4
-      '@codemirror/view': 6.43.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
       '@lezer/highlight': 1.2.3
 
-  '@codemirror/view@6.43.11':
+  '@codemirror/view@6.43.10':
     dependencies:
-      '@codemirror/state': 6.7.4
+      '@codemirror/state': 6.7.2
       crelt: 1.0.7
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
@@ -2671,24 +2683,24 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@uiw/codemirror-extensions-basic-setup@4.25.11(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.11.0)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.4)(@codemirror/view@6.43.11)':
+  '@uiw/codemirror-extensions-basic-setup@4.25.11(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.11.0)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.2)(@codemirror/view@6.43.10)':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/commands': 6.11.0
-      '@codemirror/language': 6.12.4
+      '@codemirror/language': 6.12.3
       '@codemirror/lint': 6.9.7
       '@codemirror/search': 6.7.2
-      '@codemirror/state': 6.7.4
-      '@codemirror/view': 6.43.11
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
 
-  '@uiw/react-codemirror@4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.4)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.11)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@uiw/react-codemirror@4.25.11(@babel/runtime@7.29.7)(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.2)(@codemirror/theme-one-dark@6.1.3)(@codemirror/view@6.43.10)(codemirror@6.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@codemirror/commands': 6.11.0
-      '@codemirror/state': 6.7.4
+      '@codemirror/state': 6.7.2
       '@codemirror/theme-one-dark': 6.1.3
-      '@codemirror/view': 6.43.11
-      '@uiw/codemirror-extensions-basic-setup': 4.25.11(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.11.0)(@codemirror/language@6.12.4)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.4)(@codemirror/view@6.43.11)
+      '@codemirror/view': 6.43.10
+      '@uiw/codemirror-extensions-basic-setup': 4.25.11(@codemirror/autocomplete@6.20.3)(@codemirror/commands@6.11.0)(@codemirror/language@6.12.3)(@codemirror/lint@6.9.7)(@codemirror/search@6.7.2)(@codemirror/state@6.7.2)(@codemirror/view@6.43.10)
       codemirror: 6.0.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -2754,11 +2766,11 @@ snapshots:
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/commands': 6.11.0
-      '@codemirror/language': 6.12.4
+      '@codemirror/language': 6.12.3
       '@codemirror/lint': 6.9.7
       '@codemirror/search': 6.7.2
-      '@codemirror/state': 6.7.4
-      '@codemirror/view': 6.43.11
+      '@codemirror/state': 6.7.2
+      '@codemirror/view': 6.43.10
 
   comma-separated-tokens@2.0.3: {}
 

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -147,7 +147,9 @@ pub(crate) fn engine_home(env_key: Option<&str>, default_dir: &str) -> PathBuf {
             return PathBuf::from(value);
         }
     }
-    dirs::home_dir().unwrap_or_default().join(default_dir)
+    std::env::home_dir()
+        .unwrap_or_default()
+        .join(default_dir)
 }
 
 /// A leading '-' would parse as a flag (pi also treats '@' as a file

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -56,8 +56,8 @@ pub struct BuiltCommand {
     pub preassigned_session_id: Option<String>,
 }
 
+#[derive(Debug)]
 pub enum EngineEvent {
-    /// Streaming text delta (append).
     Delta(String),
     /// Reasoning/thinking delta (append).
     Thinking(String),
@@ -229,42 +229,49 @@ impl ProcessRegistry {
         }
     }
 
-    pub fn kill(&self, key: &str) -> bool {
-        let entry = match self.0.lock() {
-            Ok(map) => map
-                .get(key)
-                .map(|e| (e.pid, Arc::clone(&e.child), Arc::clone(&e.killed))),
-            Err(_) => None,
-        };
-        // Fallback: the frontend may cancel by run id after the entry was
-        // rekeyed to the native session id.
-        let entry = entry.or_else(|| {
-            self.0.lock().ok().and_then(|map| {
-                map.values()
-                    .find(|e| e.run_id == key)
-                    .map(|e| (e.pid, Arc::clone(&e.child), Arc::clone(&e.killed)))
-            })
-        });
-        let Some((pid, child, killed)) = entry else {
-            return false;
-        };
+    /// Kill one entry (pid-reuse guarded). Returns false when the child was
+    /// already reaped — nothing left to signal.
+    fn kill_entry(pid: u32, child: &Arc<TokioMutex<tokio::process::Child>>, killed: &Arc<std::sync::atomic::AtomicBool>) -> bool {
         killed.store(true, std::sync::atomic::Ordering::SeqCst);
         if let Ok(mut guard) = child.try_lock() {
             // Pid-reuse guard: a reaped child's pid may already belong to
             // someone else — never signal a group we no longer own.
             match guard.try_wait() {
-                Ok(Some(_)) => {}
+                Ok(Some(_)) => false,
                 _ => {
                     kill_process_group(pid);
                     let _ = guard.start_kill();
+                    true
                 }
             }
         } else {
             // The runner holds the lock only while reaping post-EOF; that
             // window is tiny and the kill flag already settles the turn.
             kill_process_group(pid);
+            true
         }
-        true
+    }
+
+    /// Kill **every** entry matching `key`: the map key (native session id or
+    /// run id) and the recorded run id both match. One session resumed into
+    /// several parallel runs must all die on a single stop, or the survivors
+    /// keep streaming and fight the next run over the session file.
+    pub fn kill(&self, key: &str) -> bool {
+        let entries: Vec<(u32, Arc<TokioMutex<tokio::process::Child>>, Arc<std::sync::atomic::AtomicBool>)> =
+            match self.0.lock() {
+                Ok(map) => map
+                    .iter()
+                    .filter(|(k, e)| *k == key || e.run_id == key)
+                    .map(|(_, e)| (e.pid, Arc::clone(&e.child), Arc::clone(&e.killed)))
+                    .collect(),
+                Err(_) => Vec::new(),
+            };
+        if entries.is_empty() {
+            return false;
+        }
+        entries
+            .iter()
+            .any(|(pid, child, killed)| Self::kill_entry(*pid, child, killed))
     }
 
     pub fn kill_all(&self) {
@@ -701,18 +708,28 @@ async fn run_reader(stdout: ChildStdout, ctx: RunContext) {
     for path in &ctx.cleanup_files {
         let _ = std::fs::remove_file(path);
     }
-    if let Some(key) = state.native_session_id.clone() {
-        ctx.registry.remove_if_pid(&key, ctx.pid);
+    // omp writes some failures (upstream 403/5xx, quota exhaustion) to
+    // stderr and then exits — sometimes cleanly, after a normal turn_end.
+    // A non-empty stderr on a failed exit must reach the user even when a
+    // done/error event already settled the turn; dropping it hides exactly
+    // the errors the user cannot otherwise see.
+    let stderr_tail = ctx
+        .stderr_buf
+        .lock()
+        .map(|g| redact_secrets(g.trim()))
+        .unwrap_or_default();
+    let failed = status.map(|s| !s.success()).unwrap_or(true);
+    if failed && !state.saw_error && !stderr_tail.is_empty() {
+        state.push(
+            &ctx.sink,
+            &ctx.run_id,
+            &ctx.engine_id,
+            "warn",
+            Value::String(format!("engine stderr: {stderr_tail}")),
+        );
     }
-    ctx.registry.remove_if_pid(&ctx.run_id, ctx.pid);
 
     if !state.saw_done && !state.saw_error {
-        let stderr_tail = ctx
-            .stderr_buf
-            .lock()
-            .map(|g| g.trim().to_string())
-            .unwrap_or_default();
-        let failed = status.map(|s| !s.success()).unwrap_or(true);
         let killed = ctx.killed.load(std::sync::atomic::Ordering::SeqCst);
         if killed {
             // User-initiated stop: commit whatever streamed so far as a
@@ -733,7 +750,7 @@ async fn run_reader(stdout: ChildStdout, ctx: RunContext) {
                     .unwrap_or_else(|| "unknown".to_string())
             );
             if !stderr_tail.is_empty() {
-                message.push_str(&format!(": {}", redact_secrets(&stderr_tail)));
+                message.push_str(&format!(": {stderr_tail}"));
             }
             state.push(
                 &ctx.sink,

--- a/src-tauri/src/engine/pi_family.rs
+++ b/src-tauri/src/engine/pi_family.rs
@@ -144,22 +144,15 @@ fn parse_pi_family_line(line: &str, out: &mut Vec<EngineEvent>) {
             // A message-level error is one failed model call (e.g. an
             // upstream 429): the CLI retries and the turn continues, so this
             // is only a notice. turn_end/agent_end errors stay terminal.
-            if let Some(error) = value
-                .get("message")
-                .and_then(|m| m.get("errorMessage"))
-                .and_then(Value::as_str)
-                .or_else(|| value.get("errorMessage").and_then(Value::as_str))
-            {
-                if !error.trim().is_empty() {
-                    out.push(EngineEvent::Warn(error.trim().to_string()));
-                }
+            // omp shapes vary by version: `message.errorMessage`, top-level
+            // `errorMessage`, and nested `error.message` / `message.error`.
+            if let Some(error) = nested_error_text(&value, &["message"]) {
+                out.push(EngineEvent::Warn(error));
             }
         }
         "turn_end" | "agent_end" => {
-            if let Some(error) = value.get("errorMessage").and_then(Value::as_str) {
-                if !error.trim().is_empty() {
-                    out.push(EngineEvent::Error(error.trim().to_string()));
-                }
+            if let Some(error) = nested_error_text(&value, &[]) {
+                out.push(EngineEvent::Error(error));
             }
             // No terminal result event exists in this protocol; the runner
             // emits Done on clean EOF. agent_end still settles the turn.
@@ -186,6 +179,33 @@ pub fn tool_label(name: &str, intent: Option<&str>) -> String {
         }
         _ => name.to_string(),
     }
+}
+
+/// Find the first non-empty error text across the shapes omp emits:
+/// `<prefix>.errorMessage`, top-level `errorMessage`, `error.message`, and
+/// `<prefix>.error` / `error.error` when they are plain strings. Returns the
+/// trimmed text; None when the event carries no error.
+fn nested_error_text(value: &Value, prefix: &[&str]) -> Option<String> {
+    let mut candidates: Vec<Option<&str>> = Vec::new();
+    for pre in prefix {
+        candidates.push(
+            value
+                .get(*pre)
+                .and_then(|m| m.get("errorMessage"))
+                .and_then(Value::as_str),
+        );
+    }
+    candidates.push(value.get("errorMessage").and_then(Value::as_str));
+    candidates.push(value.get("error").and_then(|e| e.get("message")).and_then(Value::as_str));
+    for pre in prefix {
+        candidates.push(value.get(*pre).and_then(|m| m.get("error")).and_then(Value::as_str));
+    }
+    candidates
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|text| !text.is_empty())
+        .map(str::to_string)
 }
 
 #[cfg(test)]
@@ -226,6 +246,38 @@ mod tests {
         match &out[0] {
             EngineEvent::Message { path, .. } => assert_eq!(*path, None),
             _ => panic!("expected tool message"),
+        }
+    }
+
+    #[test]
+    fn message_end_extracts_nested_error_shapes_as_warn() {
+        for line in [
+            serde_json::json!({"type":"message_end","message":{"errorMessage":"upstream 429"}}),
+            serde_json::json!({"type":"message_end","errorMessage":"top-level 429"}),
+            serde_json::json!({"type":"message_end","error":{"message":"nested 429"}}),
+            serde_json::json!({"type":"message_end","message":{"error":"message.error 429"}}),
+        ] {
+            let mut out = Vec::new();
+            parse_pi_family_line(&line.to_string(), &mut out);
+            match out.last() {
+                Some(EngineEvent::Warn(text)) => assert!(text.contains("429"), "{line}"),
+                other => panic!("expected Warn for {line}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn turn_end_extracts_error_from_all_shapes() {
+        for line in [
+            serde_json::json!({"type":"turn_end","errorMessage":"boom"}),
+            serde_json::json!({"type":"turn_end","error":{"message":"nested boom"}}),
+        ] {
+            let mut out = Vec::new();
+            parse_pi_family_line(&line.to_string(), &mut out);
+            match out.first() {
+                Some(EngineEvent::Error(text)) => assert!(text.contains("boom"), "{line}"),
+                other => panic!("expected Error for {line}, got {other:?}"),
+            }
         }
     }
 }

--- a/src-tauri/src/history/extract.rs
+++ b/src-tauri/src/history/extract.rs
@@ -924,7 +924,18 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].role, "user");
         assert_eq!(rows[0].text, "what is this");
-        assert_eq!(rows[0].images, ["/tmp/a.png", "/tmp/b.jpg"]);
+        // `PathBuf::join` normalizes "/"-rooted refs per platform ("/tmp/a.png"
+        // stays verbatim, "b.jpg" joins with the platform separator), so
+        // compare Path equality instead of string equality.
+        let got: Vec<std::path::PathBuf> =
+            rows[0].images.iter().map(std::path::PathBuf::from).collect();
+        assert_eq!(
+            got,
+            vec![
+                std::path::PathBuf::from("/tmp/a.png"),
+                std::path::Path::new("/tmp").join("b.jpg"),
+            ]
+        );
     }
 
     #[test]

--- a/src-tauri/src/history/scanner.rs
+++ b/src-tauri/src/history/scanner.rs
@@ -793,21 +793,41 @@ mod tests {
     static HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     struct HomeGuard {
         _lock: std::sync::MutexGuard<'static, ()>,
-        prev: Option<std::ffi::OsString>,
+        prev: Option<HomeEnvPair>,
     }
     impl HomeGuard {
         fn set(home: &Path) -> Self {
             let lock = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
             let prev = std::env::var_os("HOME");
             std::env::set_var("HOME", home);
-            Self { _lock: lock, prev }
+            // `dirs` resolves the Windows profile from the user's shell
+            // registry entry, ignoring HOME; USERPROFILE is what engine_home
+            // falls back to there, so both must point at the scratch home.
+            let prev_profile = std::env::var_os("USERPROFILE");
+            std::env::set_var("USERPROFILE", home);
+            Self {
+                _lock: lock,
+                prev: prev.map(|p| HomeEnvPair(Some(p), prev_profile)),
+            }
         }
     }
+
+    struct HomeEnvPair(
+        Option<std::ffi::OsString>,
+        Option<std::ffi::OsString>,
+    );
+
     impl Drop for HomeGuard {
         fn drop(&mut self) {
-            match &self.prev {
-                Some(value) => std::env::set_var("HOME", value),
-                None => std::env::remove_var("HOME"),
+            if let Some(HomeEnvPair(home, profile)) = &self.prev {
+                match home {
+                    Some(value) => std::env::set_var("HOME", value),
+                    None => std::env::remove_var("HOME"),
+                }
+                match profile {
+                    Some(value) => std::env::set_var("USERPROFILE", value),
+                    None => std::env::remove_var("USERPROFILE"),
+                }
             }
         }
     }
@@ -922,7 +942,7 @@ mod tests {
                 "{\"type\":\"title\",\"v\":1,\"title\":\"t\"}",
                 format!(
                     "{{\"type\":\"session\",\"version\":3,\"id\":\"sid-1\",\"timestamp\":\"2026-09-05T07:13:57.946Z\",\"cwd\":\"{}\"}}",
-                    workspace.display()
+                    workspace.display().to_string().replace('\\', "\\\\")
                 ),
                 "{\"type\":\"message\",\"timestamp\":\"2026-09-05T07:14:06.682Z\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}}",
             ),
@@ -1039,15 +1059,11 @@ mod tests {
             .join("06");
         std::fs::create_dir_all(&rollout_dir).map_err(|e| e.to_string())?;
         let big_instructions = "x".repeat(40 * 1024);
+        let cwd_json = workspace.display().to_string().replace('\\', "\\\\");
         std::fs::write(
             rollout_dir.join("rollout-2026-09-06T21-52-11-sid-codex.jsonl"),
             format!(
-                "{}\n{}\n",
-                format!(
-                    "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"sid-codex\",\"cwd\":\"{}\",\"base_instructions\":{{\"text\":\"{big_instructions}\"}}}}}}",
-                    workspace.display()
-                ),
-                "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":[{\"type\":\"input_text\",\"text\":\"你好啊\"}]}}",
+                "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"sid-codex\",\"cwd\":\"{cwd_json}\",\"base_instructions\":{{\"text\":\"{big_instructions}\"}}}}}}\n{{\"type\":\"response_item\",\"payload\":{{\"type\":\"message\",\"role\":\"user\",\"content\":[{{\"type\":\"input_text\",\"text\":\"你好啊\"}}]}}}}\n",
             ),
         )
         .map_err(|e| e.to_string())?;

--- a/src/features/chat/components/ProcessDisclosure.tsx
+++ b/src/features/chat/components/ProcessDisclosure.tsx
@@ -103,9 +103,26 @@ function FrozenStepRow({
   );
 }
 
+/** Live thinking window: the last ~2000 chars, cut at a LINE boundary so a
+ *  row slides out as a whole instead of dissolving character by character.
+ *  `truncated` tells the surface to fade its top edge, hinting at the
+ *  content above the window. */
+function liveThinkingWindow(text: string): { body: string; truncated: boolean } {
+  const WINDOW_CHARS = 2000;
+  if (text.length <= WINDOW_CHARS) return { body: text, truncated: false };
+  const cut = text.length - WINDOW_CHARS;
+  const newline = text.indexOf("\n", cut);
+  // No newline inside the window (one enormous line): keep the char cut —
+  // there is no line boundary to honor.
+  const start = newline === -1 ? cut : newline + 1;
+  return { body: text.slice(start), truncated: true };
+}
+
 /** Thinking body: brain header + left-railed gray content, mirroring the
  * reference chat UI. Plain pre-wrapped text — never markdown-reparsed per
- * delta; the live view is windowed to the last 2000 chars. */
+ * delta. The live view is windowed to the last 2000 chars; the cut lands on
+ * a line boundary and the top edge fades out, so overflow leaves as whole
+ * dissolving rows rather than a hard char-by-char wipe. */
 function ThinkingSurface({
   text,
   title,
@@ -115,6 +132,7 @@ function ThinkingSurface({
   title?: string;
   live?: boolean;
 }) {
+  const { body, truncated } = live ? liveThinkingWindow(text) : { body: text, truncated: false };
   return (
     <div className="flex flex-col gap-1">
       {title && (
@@ -123,8 +141,14 @@ function ThinkingSurface({
           <span>{title}</span>
         </div>
       )}
-      <div className="ml-2 whitespace-pre-wrap break-words border-l border-foreground-icon-quaternary pl-4 text-[12px] leading-[1.65] text-text-tertiary">
-        {live ? text.slice(-2000) : text}
+      <div
+        className={cx(
+          "ml-2 whitespace-pre-wrap break-words border-l border-foreground-icon-quaternary pl-4 text-[12px] leading-[1.65] text-text-tertiary",
+          truncated &&
+            "[mask-image:linear-gradient(to_bottom,transparent_0,#000_36px)] [-webkit-mask-image:linear-gradient(to_bottom,transparent_0,#000_36px)]",
+        )}
+      >
+        {body}
       </div>
     </div>
   );

--- a/src/features/chat/components/ProcessDisclosure.tsx
+++ b/src/features/chat/components/ProcessDisclosure.tsx
@@ -154,23 +154,35 @@ function ThinkingSurface({
   );
 }
 
-/** Expanded-state machine: automation opens the latest row and folds older
- * ones as the turn settles, until the user's own click takes over. */
-function useProcessExpansion(autoExpand: boolean, turnLive: boolean) {
+/** Expanded-state machine: automation opens a row while its thinking is
+ *  streaming and folds it the moment that thinking settles (the user asked
+ *  for exactly that rhythm); a superseded or turn-settled row folds too,
+ *  until the user's own click takes over. */
+function useProcessExpansion(autoExpand: boolean, turnLive: boolean, hasLiveThinking: boolean) {
   const [expanded, setExpanded] = useState(autoExpand);
   // Once the user clicks the header, their choice wins over the auto
-  // expand/collapse driven by newer rows appearing below.
+  // expand/collapse driven by streaming state below.
   const [overridden, setOverridden] = useState(false);
   // React-blessed adjust-during-render: previous prop values live in state,
   // so a prop change settles in the same commit that observed it — no
   // one-frame paint of the stale expanded value.
-  const [prev, setPrev] = useState({ auto: autoExpand, live: turnLive });
-  if (prev.auto !== autoExpand || prev.live !== turnLive) {
-    setPrev({ auto: autoExpand, live: turnLive });
+  const [prev, setPrev] = useState({ auto: autoExpand, live: turnLive, thinking: hasLiveThinking });
+  if (prev.auto !== autoExpand || prev.live !== turnLive || prev.thinking !== hasLiveThinking) {
+    setPrev({ auto: autoExpand, live: turnLive, thinking: hasLiveThinking });
     if (autoExpand && !prev.auto) {
       // Became the latest row: open it and hand control back to automation.
       setOverridden(false);
       setExpanded(true);
+    } else if (hasLiveThinking && !prev.thinking && !overridden) {
+      // Thinking resumed inside this row (extended thinking between tool
+      // calls): show it again unless the user folded the row on purpose.
+      setExpanded(true);
+    } else if (!hasLiveThinking && prev.thinking) {
+      // The thinking settled: fold immediately — expanded-on-demand shows
+      // the full text afterwards. Control returns to automation so a later
+      // "became latest" can reopen.
+      setOverridden(false);
+      setExpanded(false);
     } else if (!autoExpand && !turnLive) {
       const superseded = prev.auto;
       const turnJustSettled = prev.live;
@@ -271,15 +283,17 @@ export const ProcessDisclosure = memo(function ProcessDisclosure({
 }: {
   items: ProcessItem[];
   autoExpand?: boolean;
-  /** True while the turn is still streaming: nothing folds away mid-turn —
-   * the reader may be watching a row grow. Older rows fold when the turn
-   * settles instead. */
+  /** True while the turn is still streaming. The row folds when its own
+   *  thinking settles even mid-turn; this only keeps pre-thinking content
+   *  (early tool rows) mounted until the turn ends. */
   turnLive?: boolean;
   processId: number;
   seenTools: Set<string>;
 }) {
   const { t } = useTranslation();
-  const { expanded, toggleExpanded } = useProcessExpansion(autoExpand, turnLive);
+  const sections = useMemo(() => groupProcessSections(items), [items]);
+  const hasLiveThinking = sections.some((s) => s.type === "thinking" && s.live);
+  const { expanded, toggleExpanded } = useProcessExpansion(autoExpand, turnLive, hasLiveThinking);
   const reduceMotion = useReducedMotion() ?? false;
   // Mark after paint, not at animation complete: a virtualizer remount
   // mid-entrance must skip the replay. New keys still play on this first
@@ -293,10 +307,11 @@ export const ProcessDisclosure = memo(function ProcessDisclosure({
   // "思考过程" title itself, and the expanded body drops the inner repeat.
   const singleThinking = items.length === 1 && items[0].type === "thinking";
   const label = processSummaryLabel(t, singleThinking, thinkingCount, toolCount);
-  // Regrouping per render walks every item; items are reference-stable
-  // between flushes (see buildRows caches), so memo on identity.
-  const sections = useMemo(() => groupProcessSections(items), [items]);
-  const showBody = expanded || turnLive;
+  // Body stays mounted while expanded or while this row's own thinking is
+  // streaming (the auto-open above makes both true then); once the thinking
+  // settles the body unmounts, so expanding later re-renders the FULL
+  // settled text — the 2000-char live window only ever applies live.
+  const showBody = expanded || hasLiveThinking;
   return (
     <div className="mb-1.5 flex flex-col">
       <button

--- a/src/lib/fileLinks.ts
+++ b/src/lib/fileLinks.ts
@@ -89,9 +89,13 @@ export function decodeFileLink(url: string) {
  * Resolve a markdown-sourced path to an absolute one. Relative paths anchor
  * at the session's workspace; absolute POSIX/Windows paths pass through.
  * Returns null for `~/` paths (home dir unknown to the frontend) and empties.
+ *
+ * Paths that arrive percent-encoded (a model or upstream tool URL-encoded a
+ * CJK filename inside an otherwise plain path) are decoded first — the
+ * filesystem never sees `%E7%BB%86…` as a literal name.
  */
 export function resolveFilePath(path: string, workspacePath: string): string | null {
-  const trimmed = path.trim();
+  const trimmed = percentDecodePath(path.trim());
   if (!trimmed) return null;
   if (trimmed.startsWith("~/")) return null;
   if (trimmed.startsWith("/") || WINDOWS_ABSOLUTE_PATH_MATCH.test(trimmed)) return trimmed;
@@ -99,4 +103,19 @@ export function resolveFilePath(path: string, workspacePath: string): string | n
   if (trimmed.startsWith("../")) return null; // escaping the workspace: don't guess
   const root = workspacePath.replace(/[/\\]+$/, "");
   return root ? `${root}/${relative}` : null;
+}
+
+/** Decode `%XX` sequences when they look like URL-encoding smuggled into a
+ *  file path (CJK filenames pasted as links). A literal path with no `%`
+ *  passes through untouched; a malformed sequence keeps the raw text. */
+function percentDecodePath(path: string): string {
+  if (!path.includes("%")) return path;
+  try {
+    const decoded = decodeURIComponent(path);
+    // Only accept when decoding actually removed escapes; otherwise the `%`
+    // was part of the real name (rare but legal).
+    return decoded === path ? path : decoded;
+  } catch {
+    return path;
+  }
 }


### PR DESCRIPTION
## 修复内容

### 1. 文件超链接提示不存在
模型输出的链接目标中 CJK 文件名常被 URL 编码（`%E7%BB%86...`），`resolveFilePath` 原样传给文件系统导致 stat 失败。现在入口先做一次 percent-decode（无 `%` 零开销直通，malformed 保留原文）。

### 2. omp 停止后会话仍在后台跑
`ProcessRegistry::kill` 原来每次只杀一个匹配 entry——同一 session 被 resume 出多个并行 run 时，一键停止只杀一个，其余存活继续烧 API 并互相干扰。改为聚合杀：map key 或 run_id 匹配的全部 entry 一起终止（保留 pid-reuse 守卫）。

### 3. omp 报错信息无法显示
两处丢失：
- `run_reader` 在收过 done/error 事件后丢弃全部 stderr——omp 把上游 403/5xx、额度耗尽写到 stderr 后退出时错误被吞。现在失败退出（非零 status）+ stderr 非空时追加 warn 事件（经 secrets 脱敏）。
- pi_family 错误提取只认顶层 `errorMessage`。新增 `nested_error_text` 覆盖 `message.errorMessage` / `error.message` / `message.error` 嵌套形状（message_end→Warn 可重试，turn_end/agent_end→Error 终态）。

### 4. 思考过程交互
- 超长 live 窗口按**行边界**截断 + 顶部渐隐 mask，替代逐字擦除
- 思考结束**自动折叠**为汇总行（即使 turn 仍在跑）；工具间隙思考恢复时自动重新展开
- 折叠后点击展开显示**完整思考全文**（2000 字符窗口仅作用于直播中）

### 附带
- 补齐 v1.0.0 缺失的直接依赖声明（`@codemirror/state` / `@codemirror/language` / `@codemirror/view` / `unified`）
- 修复 4 个 Windows 平台测试（engine_home 环境解析、kimi 路径断言、scanner JSON 转义）

## 测试
- Rust 137/137 全绿（新增 6 个错误形状提取测试）
- tsc + vite build 通过
- Windows 实机验证：链接打开、思考淡出/折叠/展开全文