### PR TITLE
fix(engine): 修复 Codex 环境变量与 Pi 自定义模型目录

### DIFF
--- a/src-tauri/src/engine/codex_provider_env.rs
+++ b/src-tauri/src/engine/codex_provider_env.rs
@@ -1,0 +1,172 @@
+//! Resolve provider-scoped environment variables for GUI-launched Codex.
+//!
+//! Finder/Dock launches do not necessarily inherit the user's interactive
+//! shell environment. Codex providers name their credential variable through
+//! `model_providers.*.env_key`; resolve only those validated names and inject
+//! missing values into the Codex child process.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::env;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use tokio::process::Command;
+use tokio::time::timeout;
+
+const FRAME_START_PREFIX: &str = "__CCGUI_CODEX_ENV_START__";
+const FRAME_END_PREFIX: &str = "__CCGUI_CODEX_ENV_END__";
+const RESOLUTION_TIMEOUT: Duration = Duration::from_secs(5);
+const SHELL_SCRIPT: &str = r#"
+for key in "$@"; do
+  printf '%s%s\n' "__CCGUI_CODEX_ENV_START__" "$key"
+  value=$(/usr/bin/printenv -- "$key" 2>/dev/null || true)
+  printf '%s\n' "$value"
+  printf '%s%s\n' "__CCGUI_CODEX_ENV_END__" "$key"
+done
+"#;
+
+pub(crate) async fn apply(command: &mut Command) {
+    let config_path = crate::engine::engine_home(Some("CODEX_HOME"), ".codex").join("config.toml");
+    let Ok(contents) = tokio::fs::read_to_string(config_path).await else {
+        return;
+    };
+    let missing: Vec<String> = collect_env_keys(&contents)
+        .into_iter()
+        .filter(|key| !env_has_non_empty_value(key))
+        .collect();
+    if missing.is_empty() {
+        return;
+    }
+    let Some(resolved) = resolve_from_login_shell(&missing).await else {
+        return;
+    };
+    for (key, value) in resolved {
+        command.env(key, value);
+    }
+}
+
+fn env_has_non_empty_value(key: &str) -> bool {
+    env::var_os(key).is_some_and(|value| !value.is_empty())
+}
+
+fn collect_env_keys(contents: &str) -> BTreeSet<String> {
+    let Ok(value) = toml::from_str::<toml::Value>(contents) else {
+        return BTreeSet::new();
+    };
+    value
+        .get("model_providers")
+        .and_then(toml::Value::as_table)
+        .into_iter()
+        .flat_map(|providers| providers.values())
+        .filter_map(|provider| provider.get("env_key"))
+        .filter_map(toml::Value::as_str)
+        .map(str::trim)
+        .filter(|key| is_valid_env_name(key))
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn is_valid_env_name(value: &str) -> bool {
+    !value.is_empty()
+        && value.chars().enumerate().all(|(index, ch)| {
+            (index == 0 && (ch == '_' || ch.is_ascii_alphabetic()))
+                || (index > 0 && (ch == '_' || ch.is_ascii_alphanumeric()))
+        })
+}
+
+async fn resolve_from_login_shell(keys: &[String]) -> Option<BTreeMap<String, String>> {
+    let shell = allowed_shell()?;
+    let mut command = Command::new(shell);
+    command
+        .arg("-l")
+        .arg("-i")
+        .arg("-c")
+        .arg(SHELL_SCRIPT)
+        .arg("ccgui")
+        .args(keys);
+    let output = timeout(RESOLUTION_TIMEOUT, command.output())
+        .await
+        .ok()?
+        .ok()?;
+    Some(parse_framed_values(&output.stdout, keys))
+}
+
+fn allowed_shell() -> Option<PathBuf> {
+    if let Some(shell) = env::var_os("SHELL") {
+        return allowlisted_shell(Path::new(&shell)).map(Path::to_path_buf);
+    }
+    let default = if cfg!(target_os = "macos") {
+        Path::new("/bin/zsh")
+    } else {
+        Path::new("/bin/bash")
+    };
+    default.exists().then(|| default.to_path_buf())
+}
+
+fn allowlisted_shell(path: &Path) -> Option<&Path> {
+    let name = path.file_name()?.to_str()?;
+    ((name == "zsh" || name == "bash") && path.is_absolute()).then_some(path)
+}
+
+fn parse_framed_values(stdout: &[u8], keys: &[String]) -> BTreeMap<String, String> {
+    let text = String::from_utf8_lossy(stdout);
+    let mut values = BTreeMap::new();
+    for key in keys {
+        let start_marker = format!("{FRAME_START_PREFIX}{key}\n");
+        let end_marker = format!("{FRAME_END_PREFIX}{key}\n");
+        let Some(start) = text.find(&start_marker) else {
+            continue;
+        };
+        let value_start = start + start_marker.len();
+        let Some(end) = text[value_start..].find(&end_marker) else {
+            continue;
+        };
+        let value = text[value_start..value_start + end].trim();
+        if !value.is_empty() {
+            values.insert(key.clone(), value.to_string());
+        }
+    }
+    values
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn collects_only_valid_provider_env_keys() {
+        let keys = collect_env_keys(
+            r#"
+[model_providers.a]
+env_key = "OPENAI_API_KEY"
+[model_providers.b]
+env_key = "TEAM_OPENAI_KEY"
+[model_providers.c]
+env_key = "bad-name"
+"#,
+        );
+        assert_eq!(
+            keys.into_iter().collect::<Vec<_>>(),
+            ["OPENAI_API_KEY", "TEAM_OPENAI_KEY"]
+        );
+    }
+
+    #[test]
+    fn parses_multiple_framed_values_without_prefix_collisions() {
+        let keys = vec!["FOO".to_string(), "FOO2".to_string()];
+        let stdout = format!(
+            "noise\n{FRAME_START_PREFIX}FOO\none\n{FRAME_END_PREFIX}FOO\n\
+             {FRAME_START_PREFIX}FOO2\ntwo\n{FRAME_END_PREFIX}FOO2\n"
+        );
+        let values = parse_framed_values(stdout.as_bytes(), &keys);
+        assert_eq!(values.get("FOO").map(String::as_str), Some("one"));
+        assert_eq!(values.get("FOO2").map(String::as_str), Some("two"));
+    }
+
+    #[test]
+    fn rejects_injection_like_names() {
+        assert!(!is_valid_env_name("OPENAI_API_KEY; touch /tmp/pwned"));
+        assert!(!is_valid_env_name("1INVALID"));
+        assert!(is_valid_env_name("CUSTOM_RELAY_TOKEN"));
+    }
+}

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -1,5 +1,6 @@
 pub mod claude;
 pub mod codex;
+mod codex_provider_env;
 pub mod dsh;
 pub mod grok;
 pub mod images;
@@ -1291,6 +1292,9 @@ pub async fn send_message(
     )?;
 
     let mut command = launch.built.command;
+    if engine == "codex" {
+        codex_provider_env::apply(&mut command).await;
+    }
     command
         .stdin(if launch.built.stdin_payload.is_some() {
             std::process::Stdio::piped()

--- a/src-tauri/src/engine/models/mod.rs
+++ b/src-tauri/src/engine/models/mod.rs
@@ -272,22 +272,26 @@ fn claude_catalog() -> EngineCatalog {
 async fn pi_family_catalog(engine: &str) -> EngineCatalog {
     let settings = crate::settings::read_settings().unwrap_or_default();
     let bin = super::engine_bin(&settings, engine);
+    let configured = pi::configured_models(engine).unwrap_or_default();
     if let Ok(models) = pi::run_models_json(&bin).await {
         if !models.is_empty() {
-            return EngineCatalog::authoritative(models);
+            return EngineCatalog::authoritative(pi::merge_configured_models(models, configured));
         }
     }
     // Fresh binaries skip extension boot; old ones fall back to a bare run.
     for extra in [&["--no-extensions"][..], &[][..]] {
         if let Ok(models) = pi::run_list_models(&bin, extra).await {
             if !models.is_empty() {
-                return EngineCatalog::authoritative(models);
+                return EngineCatalog::authoritative(pi::merge_configured_models(
+                    models,
+                    configured,
+                ));
             }
         }
     }
     // A missing/broken CLI is not an error here: the picker falls back to
     // provider-config models.
-    EngineCatalog::authoritative(Vec::new())
+    EngineCatalog::authoritative(configured)
 }
 
 /// Top-level `key = "…"` only: stop at the first `[table]` header so a

--- a/src-tauri/src/engine/models/pi.rs
+++ b/src-tauri/src/engine/models/pi.rs
@@ -1,5 +1,64 @@
 use super::{run_probe, EngineModel};
 
+pub(super) fn configured_models(engine: &str) -> Result<Vec<EngineModel>, String> {
+    let config = crate::engine::pi_family_auth::pi_family_models_config_read(engine.to_string())?;
+    let Some(text) = config.text.filter(|text| !text.trim().is_empty()) else {
+        return Ok(Vec::new());
+    };
+    let value = crate::engine::pi_family_auth::validate_models_config_text(engine, &text)?;
+    let mut models = Vec::new();
+    let Some(providers) = value
+        .get("providers")
+        .and_then(serde_json::Value::as_object)
+    else {
+        return Ok(models);
+    };
+    for (provider_id, provider) in providers {
+        let Some(entries) = provider.get("models").and_then(serde_json::Value::as_array) else {
+            continue;
+        };
+        for entry in entries {
+            let Some(model_id) = entry
+                .get("id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+            else {
+                continue;
+            };
+            models.push(EngineModel {
+                id: format!("{provider_id}/{model_id}"),
+                name: entry
+                    .get("name")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::trim)
+                    .filter(|name| !name.is_empty())
+                    .map(str::to_string),
+                description: None,
+                provider: provider_id.clone(),
+                context_window: entry
+                    .get("contextWindow")
+                    .and_then(serde_json::Value::as_u64),
+            });
+        }
+    }
+    Ok(models)
+}
+
+pub(super) fn merge_configured_models(
+    mut discovered: Vec<EngineModel>,
+    configured: Vec<EngineModel>,
+) -> Vec<EngineModel> {
+    let mut seen: std::collections::HashSet<String> =
+        discovered.iter().map(|model| model.id.clone()).collect();
+    discovered.extend(
+        configured
+            .into_iter()
+            .filter(|model| seen.insert(model.id.clone())),
+    );
+    discovered
+}
+
 /// `<bin> models --json` → {"models":[{provider,id,selector,name,contextWindow,…}]}.
 pub(super) async fn run_models_json(bin: &str) -> Result<Vec<EngineModel>, String> {
     parse_models_json(&run_probe(bin, &["models", "--json"], "models --json").await?)
@@ -162,5 +221,36 @@ kimi-code      k3             262.1K    32.8K    yes       no
         assert_eq!(parse_token_count("1M"), Some(1_000_000));
         assert_eq!(parse_token_count("8192"), Some(8192));
         assert_eq!(parse_token_count("—"), None);
+    }
+
+    #[test]
+    fn merges_custom_models_without_duplicate_selectors() {
+        let discovered = vec![EngineModel {
+            id: "relay/model-a".to_string(),
+            name: None,
+            description: None,
+            provider: "relay".to_string(),
+            context_window: None,
+        }];
+        let configured = vec![
+            EngineModel {
+                id: "relay/model-a".to_string(),
+                name: Some("duplicate".to_string()),
+                description: None,
+                provider: "relay".to_string(),
+                context_window: None,
+            },
+            EngineModel {
+                id: "private/model-b".to_string(),
+                name: Some("Model B".to_string()),
+                description: None,
+                provider: "private".to_string(),
+                context_window: Some(200_000),
+            },
+        ];
+        let merged = merge_configured_models(discovered, configured);
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].id, "relay/model-a");
+        assert_eq!(merged[1].id, "private/model-b");
     }
 }

--- a/src-tauri/src/engine/pi_family_auth.rs
+++ b/src-tauri/src/engine/pi_family_auth.rs
@@ -767,7 +767,7 @@ fn strip_jsonc_comments(input: &str) -> String {
 /// Loose structural validation: parseable, `providers` is a map, each
 /// provider's `models` items carry a string `id`. Unknown fields are accepted
 /// and preserved (the raw user text is stored verbatim).
-fn validate_models_config_text(engine: &str, text: &str) -> Result<Value, String> {
+pub(crate) fn validate_models_config_text(engine: &str, text: &str) -> Result<Value, String> {
     let value: Value = if engine == "omp" {
         serde_yaml::from_str(text).map_err(|error| {
             format!("[PI_FAMILY_MODELS_INVALID] models.yml is not valid YAML: {error}")


### PR DESCRIPTION
## Summary

- 修复 macOS GUI 启动 Codex 时 provider `env_key` 指向的系统环境变量未传入子进程的问题。
- 将 Pi/OMP 当前 profile 的 `models.json` / `models.yml` 自定义 provider/model 合并到会话模型 catalog。
- 保留 `provider/model` selector，避免设置页可见但会话选择器不可用。

## Validation

- `cargo check --manifest-path src-tauri/Cargo.toml --lib`
- Codex provider env focused tests: 3 passed
- Pi model catalog focused tests: 4 passed
- macOS Tauri GUI manual verification: passed
  - Codex provider using system environment key works
  - Pi custom models are visible and selectable
  - Selected Pi model sends successfully

## Notes

- No API key values are included in the change.
- Changes are based on upstream `v1.0.0` development branch.
