### PR TITLE
fix(theme): Windows 下切换主题时同步原生窗口主题，修复深色模式状态栏颜色

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,6 +163,7 @@ pub fn run() {
             // settings
             settings::get_app_settings,
             settings::update_app_settings,
+            settings::set_window_theme,
             // plugins
             plugins::plugin_list,
             plugins::plugin_install_from_path,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -625,3 +625,21 @@ mod tests {
         assert!(!scratch.path("settings.json").exists());
     }
 }
+#[tauri::command]
+pub fn set_window_theme(
+    app: tauri::AppHandle,
+    dark: bool,
+) -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        use tauri::{Manager, Theme};
+        if let Some(window) = app.get_webview_window("main") {
+            let _ = window.set_theme(Some(if dark {
+                Theme::Dark
+            } else {
+                Theme::Light
+            }));
+        }
+    }
+    Ok(())
+}

--- a/src/features/settings/theme.ts
+++ b/src/features/settings/theme.ts
@@ -15,6 +15,7 @@ export function applyTheme(theme: string): void {
       typeof window !== "undefined" &&
       window.matchMedia("(prefers-color-scheme: dark)").matches);
   document.documentElement.classList.toggle("dark", dark);
+  ipc.setWindowTheme(dark).catch(() => {});
   // Mirror the applied theme into storage for main.tsx's pre-paint read.
   window.localStorage.setItem(THEME_STORAGE_KEY, dark ? "dark" : "light");
 }

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -488,6 +488,8 @@ export const ipc = {
     // Keep the cache in sync with the authoritative value just persisted.
     settingsPromise = Promise.resolve(settings);
   },
+  setWindowTheme: (dark: boolean) =>
+    invoke<void>("set_window_theme", { dark }),
   // engine
   sendMessage: (args: {
     engine: string;


### PR DESCRIPTION
## 改了什么

Windows 下应用内切换深色/浅色主题时，原生窗口（标题栏/状态栏）颜色不会跟随变化，导致深色模式下状态栏仍显示浅色。本 PR 新增 Tauri command `set_window_theme`，在主题切换时同步设置原生窗口主题：

- `src-tauri/src/settings.rs`：新增 `set_window_theme` command（仅 Windows 生效，通过 `set_theme` 设置原生窗口主题）
- `src-tauri/src/lib.rs`：注册该 command
- `src/lib/ipc.ts`：新增 `setWindowTheme` IPC 封装
- `src/features/settings/theme.ts`：`applyTheme` 时调用同步原生窗口主题

## 为什么改

Windows 上 WebView 内的 UI 主题切换后，原生窗口 chrome（标题栏/滚动条/状态栏）仍保持系统主题色，深色模式下出现明显的白色状态栏/标题栏，视觉割裂。

## 怎么验证的

- `pnpm build`（tsc 类型检查 + 前端构建）通过
- `pnpm test`：205 个测试全部通过（另有 4 个 `node:test` 写法的测试文件被 Vitest 误收集报 "No test suite found"，在上游 v1.0.0 原始代码上同样复现，与本改动无关）
- `cargo test`：225 通过 / 1 失败（`plugin_caps::tests::tracked_children_kill_semantics`，并发相关 flaky，单独运行通过，且在上游原始代码上同样复现，与本改动无关）
- Windows 11 实机验证：切换深色主题后标题栏/状态栏变为深色，切回浅色恢复正常