### PR TITLE
fix(chat): 修复 Windows 盘符路径带前导斜杠或行号后缀时文件链接无法解析打开

### DIFF
--- a/src/lib/fileLinks.ts
+++ b/src/lib/fileLinks.ts
@@ -63,7 +63,7 @@ function isPathCandidate(value: string) {
 
 /** True when an inline-code / link-target string is a plausible file path. */
 export function isLinkableFilePath(value: string) {
-  const trimmed = value.trim();
+  const trimmed = stripFileLocation(value.trim());
   if (!trimmed || !FILE_PATH_MATCH.test(trimmed)) return false;
   return isPathCandidate(trimmed);
 }
@@ -87,7 +87,7 @@ export function decodeFileLink(url: string) {
 
 /**
  * Resolve a markdown-sourced path to an absolute one. Relative paths anchor
- * at the session's workspace; absolute POSIX/Windows paths pass through.
+ * at the session's workspace; slash-prefixed Windows drive paths are normalized.
  * Returns null for `~/` paths (home dir unknown to the frontend) and empties.
  *
  * Paths that arrive percent-encoded (a model or upstream tool URL-encoded a
@@ -95,14 +95,26 @@ export function decodeFileLink(url: string) {
  * filesystem never sees `%E7%BB%86…` as a literal name.
  */
 export function resolveFilePath(path: string, workspacePath: string): string | null {
-  const trimmed = percentDecodePath(path.trim());
+  // Strip the leading slash on `/D:/...` (Git-Bash / MSYS style drive prefix)
+  // *before* stripping the `:line[:col]` suffix. Doing the location strip
+  // first leaves the `/` in place only in odd inputs; normalizing the drive
+  // prefix up-front keeps every downstream check (absolute detection, reveal,
+  // open) operating on the real disk path.
+  const deSlashed = path.trim().replace(/^\/+(?=[A-Za-z]:[\\/])/, "");
+  const trimmed = percentDecodePath(stripFileLocation(deSlashed));
   if (!trimmed) return null;
   if (trimmed.startsWith("~/")) return null;
-  if (trimmed.startsWith("/") || WINDOWS_ABSOLUTE_PATH_MATCH.test(trimmed)) return trimmed;
+  if (trimmed.startsWith("/") || /^[A-Za-z]:[\\/]/.test(trimmed)) return trimmed;
   const relative = trimmed.replace(/^\.\//, "");
   if (trimmed.startsWith("../")) return null; // escaping the workspace: don't guess
   const root = workspacePath.replace(/[/\\]+$/, "");
   return root ? `${root}/${relative}` : null;
+}
+
+/** Strip source locations before URL-decoding, preserving encoded filename
+ * characters such as `%23L53` that are not navigation suffixes. */
+function stripFileLocation(path: string): string {
+  return path.replace(/(?::\d+(?::\d+)?|#L\d+(?:C\d+)?(?:-L?\d+(?:C\d+)?)?)$/i, "");
 }
 
 /** Decode `%XX` sequences when they look like URL-encoding smuggled into a


### PR DESCRIPTION
## 改了什么

`src/lib/fileLinks.ts` 两处修改：

1. `resolveFilePath`：先剥离 `/D:/...`、`//D:/...` 这类 Git-Bash/MSYS 风格的前导斜杠盘符前缀，再剥离 `:line[:col]` / `#L53` 行号后缀，最后统一用盘符模式判定 Windows 绝对路径。
2. `isLinkableFilePath`：检测前同样剥离行号后缀，带 `:53` 的路径在检测层即可被识别为文件链接（此前会在检测层被拒，根本不渲染成链接）。

## 为什么改

Windows 下点击聊天中的文件链接报错：

```
cannot resolve /D:/KaiFaRuanJian/RustSource/desktop-cc-gui/src-tauri/src/engine: 文件名、目录名或卷标语法不正确。 (os error 123)
cannot resolve /D:/dev/workspace/kezhuan/docs: 文件名、目录名或卷标语法不正确。 (os error 123)
```

前端把 `/D:/...`（前导斜杠来自 Git-Bash/MSYS 输出，行号 `:53` 来自模型输出）原样传给了后端。左键打开、右键打开/在资源管理器中显示三处都汇入共享的 `resolveFilePath`，修复一处即全部覆盖；目录路径、不带行号的路径同样被覆盖。

## 怎么验证的

- `pnpm build` 通过（类型检查）
- `pnpm test`：205 个测试全部通过；4 个 `tests/` 目录下的套件在未修改的基线上同样报 `No test suite found`（既有环境问题，与本改动无关，已用 stash 对照确认）