### PR TITLE
fix(usage): codex tails its rollout from the end, not from byte 0

### DIFF
--- a/src-tauri/src/engine/codex_usage.rs
+++ b/src-tauri/src/engine/codex_usage.rs
@@ -11,6 +11,11 @@
 //! numbers until the next response and therefore only feed the context
 //! window; `token_usage_record` is the once-per-response report this tail
 //! emits, so a turn's usage is the sum of its records.
+//!
+//! The tail starts at the file's end: `codex exec resume` appends to the
+//! rollout the thread wrote the first time, so byte 0 is the thread's whole
+//! history — reading from there ledgers every past response again on every
+//! launch.
 
 use serde_json::Value;
 use std::fs::File;
@@ -27,18 +32,24 @@ pub struct UsageTail {
 }
 
 impl UsageTail {
-    /// Open the rollout backing `thread_id`. None until the CLI has created
-    /// the file, so callers retry while the run streams.
+    /// Open the rollout backing `thread_id`, reporting only what the CLI
+    /// appends from here on. None until the CLI has created the file, so
+    /// callers retry while the run streams.
     pub fn open(thread_id: &str) -> Option<Self> {
         let home = crate::engine::engine_home(Some("CODEX_HOME"), ".codex");
         Self::open_in(&home, thread_id)
     }
 
     fn open_in(home: &Path, thread_id: &str) -> Option<Self> {
-        let file = File::open(rollout_path(home, thread_id)?).ok()?;
+        let mut file = File::open(rollout_path(home, thread_id)?).ok()?;
+        // Anything already in the file belongs to earlier turns — a resumed
+        // thread's rollout carries the entire thread. Start where the CLI
+        // will write next; a half-written trailing line fails to parse and is
+        // skipped, so starting mid-line costs nothing.
+        let offset = file.seek(SeekFrom::End(0)).ok()?;
         Some(Self {
             file,
-            offset: 0,
+            offset,
             context_window: None,
         })
     }
@@ -223,6 +234,39 @@ mod tests {
         assert_eq!(polled[0]["cache_write_input_tokens"], 500);
         assert_eq!(polled[1]["output_tokens"], 60);
         assert!(tail.poll().is_empty(), "already read");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// `codex exec resume` appends to the rollout the thread wrote the first
+    /// time, so the file already holds every past response. One real thread's
+    /// 47 MB rollout carried 771 records summing to 102M tokens; reading from
+    /// byte 0 ledgered all of them again on every launch.
+    #[test]
+    fn history_already_in_the_rollout_is_not_reported() {
+        let dir = scratch("resume");
+        let day = dir.join("sessions").join("2026").join("09").join("11");
+        std::fs::create_dir_all(&day).unwrap();
+        let path = day.join("rollout-2026-09-11T01-00-00-t-4.jsonl");
+        std::fs::write(
+            &path,
+            format!(
+                "{}{}",
+                record_line(9_000, 500, 9_500),
+                record_line(8_000, 400, 8_400)
+            ),
+        )
+        .unwrap();
+
+        let mut tail = UsageTail::open_in(&dir, "t-4").expect("tail opens");
+        assert!(
+            tail.poll().is_empty(),
+            "earlier turns are not this run's usage"
+        );
+
+        append(&path, &record_line(1_000, 40, 1_040));
+        let polled = tail.poll();
+        assert_eq!(polled.len(), 1, "only what was appended after open");
+        assert_eq!(polled[0]["input_tokens"], 1_000);
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -1245,10 +1245,14 @@ async fn run_reader(stdout: ChildStdout, ctx: RunContext) {
     let is_codex = ctx.engine_id == "codex";
     let mut usage_tail: Option<codex_usage::UsageTail> = None;
     // Only the stream's own thread id (thread.started) may open the log: a
-    // resumed run's preassigned id names the *old* session, whose archived
-    // rollout would replay yesterday's records as if they were live.
+    // resumed run's preassigned id can name a thread the CLI is no longer
+    // writing to, and tailing that file would miss this run's reports.
     let mut stream_session_id = false;
-    let mut tail_lookup_at = std::time::Instant::now();
+    // The CLI writes the rollout at thread start, so the open normally
+    // succeeds on the first tick. Bound the retries anyway: each one walks
+    // the whole `sessions/**` tree, and a run whose home is not the one being
+    // written would walk it every tick for the length of the turn.
+    let mut tail_attempts = 0u32;
     let mut poll = tokio::time::interval(std::time::Duration::from_millis(500));
     poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     loop {
@@ -1260,12 +1264,12 @@ async fn run_reader(stdout: ChildStdout, ctx: RunContext) {
                         for usage in tail.poll() {
                             ctx.dispatch_event(&mut state, EngineEvent::Usage(usage));
                         }
-                    } else if stream_session_id
-                        && tail_lookup_at.elapsed() >= std::time::Duration::from_secs(1)
-                    {
+                    } else if stream_session_id && tail_attempts < 20 {
                         // The CLI creates the log a moment after the thread
-                        // id arrives; until then there is nothing to open.
-                        tail_lookup_at = std::time::Instant::now();
+                        // id arrives. Attempt every tick rather than backing
+                        // off: the tail starts at the file's end, so any wait
+                        // here is a window in which a record lands unread.
+                        tail_attempts += 1;
                         usage_tail = state
                             .native_session_id
                             .as_deref()


### PR DESCRIPTION
## 问题

用量页的「Token 累计」在 codex **刚启动、任务还没开始**时就跳涨 100M。

`UsageTail` 以 `offset: 0` 打开 codex 的 rollout 日志，但 `codex exec resume` 是**追加**写回该线程第一次创建的那个文件——字节 0 处是整条线程的全部历史。于是每次启动都把历史里每一条 `token_usage_record` 当作本次运行的新报告重新入账。

本机实测（线程 `01a08ac3`，47MB rollout）：

| 文件内 `token_usage_record` | 累加 in+out | 台账中该组合的副本数 |
|---|---|---|
| 771 条 | 102,079,195 | 6 份（逐字节相同） |

台账记了 616M，实际只花了 106M。另一条会话 `01a08ff9` 复现了同一机制的小号版本：某次 resume 在 4 毫秒内写入 42 行，正好等于该 rollout 里时间戳早于那一刻的 42 条记录。

## 改动

`src-tauri/src/engine/codex_usage.rs`

- tail 锚定到**文件末尾**，只上报 CLI 从此刻起追加的内容。写了一半的尾行解析失败会被跳过，所以从行中间起算没有代价。

`src-tauri/src/engine/mod.rs`

- 打开 tail 的重试原有 1 秒退避。锚点改成 EOF 之后，任何等待都是一个「记录落盘却读不到」的窗口，所以改为**每个 tick 都尝试**，并以次数封顶（20 次 ≈ 10s）——每次尝试都要遍历 `sessions/**`，若某次运行的 CODEX_HOME 并非正在被写入的那个，无界重试会整轮持续遍历。
- 原注释称「resumed id 会重放昨天的记录」，描述的机制是错的（重放源于 offset，不是 id）。改为陈述真实理由：预置 id 可能指向 CLI 已不再写入的线程，tail 它会**漏掉**本次运行的报告。

## 回归

`history_already_in_the_rollout_is_not_reported`：文件预置两条记录 → `poll()` 必须为空 → 追加一条 → 只报这一条。

`cargo test --lib`：230 passed, 0 failed。CI 全绿。
