### PR TITLE
feat(open-app,usage): 顶栏添加自定义程序与图标提取、codex 用量台账尾部修正

### DIFF
--- a/src-tauri/src/engine/codex_usage.rs
+++ b/src-tauri/src/engine/codex_usage.rs
@@ -11,6 +11,11 @@
 //! numbers until the next response and therefore only feed the context
 //! window; `token_usage_record` is the once-per-response report this tail
 //! emits, so a turn's usage is the sum of its records.
+//!
+//! The tail starts at the file's end: `codex exec resume` appends to the
+//! rollout the thread wrote the first time, so byte 0 is the thread's whole
+//! history — reading from there ledgers every past response again on every
+//! launch.
 
 use serde_json::Value;
 use std::fs::File;
@@ -27,18 +32,24 @@ pub struct UsageTail {
 }
 
 impl UsageTail {
-    /// Open the rollout backing `thread_id`. None until the CLI has created
-    /// the file, so callers retry while the run streams.
+    /// Open the rollout backing `thread_id`, reporting only what the CLI
+    /// appends from here on. None until the CLI has created the file, so
+    /// callers retry while the run streams.
     pub fn open(thread_id: &str) -> Option<Self> {
         let home = crate::engine::engine_home(Some("CODEX_HOME"), ".codex");
         Self::open_in(&home, thread_id)
     }
 
     fn open_in(home: &Path, thread_id: &str) -> Option<Self> {
-        let file = File::open(rollout_path(home, thread_id)?).ok()?;
+        let mut file = File::open(rollout_path(home, thread_id)?).ok()?;
+        // Anything already in the file belongs to earlier turns — a resumed
+        // thread's rollout carries the entire thread. Start where the CLI
+        // will write next; a half-written trailing line fails to parse and is
+        // skipped, so starting mid-line costs nothing.
+        let offset = file.seek(SeekFrom::End(0)).ok()?;
         Some(Self {
             file,
-            offset: 0,
+            offset,
             context_window: None,
         })
     }
@@ -223,6 +234,39 @@ mod tests {
         assert_eq!(polled[0]["cache_write_input_tokens"], 500);
         assert_eq!(polled[1]["output_tokens"], 60);
         assert!(tail.poll().is_empty(), "already read");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// `codex exec resume` appends to the rollout the thread wrote the first
+    /// time, so the file already holds every past response. One real thread's
+    /// 47 MB rollout carried 771 records summing to 102M tokens; reading from
+    /// byte 0 ledgered all of them again on every launch.
+    #[test]
+    fn history_already_in_the_rollout_is_not_reported() {
+        let dir = scratch("resume");
+        let day = dir.join("sessions").join("2026").join("09").join("11");
+        std::fs::create_dir_all(&day).unwrap();
+        let path = day.join("rollout-2026-09-11T01-00-00-t-4.jsonl");
+        std::fs::write(
+            &path,
+            format!(
+                "{}{}",
+                record_line(9_000, 500, 9_500),
+                record_line(8_000, 400, 8_400)
+            ),
+        )
+        .unwrap();
+
+        let mut tail = UsageTail::open_in(&dir, "t-4").expect("tail opens");
+        assert!(
+            tail.poll().is_empty(),
+            "earlier turns are not this run's usage"
+        );
+
+        append(&path, &record_line(1_000, 40, 1_040));
+        let polled = tail.poll();
+        assert_eq!(polled.len(), 1, "only what was appended after open");
+        assert_eq!(polled[0]["input_tokens"], 1_000);
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -1245,10 +1245,14 @@ async fn run_reader(stdout: ChildStdout, ctx: RunContext) {
     let is_codex = ctx.engine_id == "codex";
     let mut usage_tail: Option<codex_usage::UsageTail> = None;
     // Only the stream's own thread id (thread.started) may open the log: a
-    // resumed run's preassigned id names the *old* session, whose archived
-    // rollout would replay yesterday's records as if they were live.
+    // resumed run's preassigned id can name a thread the CLI is no longer
+    // writing to, and tailing that file would miss this run's reports.
     let mut stream_session_id = false;
-    let mut tail_lookup_at = std::time::Instant::now();
+    // The CLI writes the rollout at thread start, so the open normally
+    // succeeds on the first tick. Bound the retries anyway: each one walks
+    // the whole `sessions/**` tree, and a run whose home is not the one being
+    // written would walk it every tick for the length of the turn.
+    let mut tail_attempts = 0u32;
     let mut poll = tokio::time::interval(std::time::Duration::from_millis(500));
     poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     loop {
@@ -1260,12 +1264,12 @@ async fn run_reader(stdout: ChildStdout, ctx: RunContext) {
                         for usage in tail.poll() {
                             ctx.dispatch_event(&mut state, EngineEvent::Usage(usage));
                         }
-                    } else if stream_session_id
-                        && tail_lookup_at.elapsed() >= std::time::Duration::from_secs(1)
-                    {
+                    } else if stream_session_id && tail_attempts < 20 {
                         // The CLI creates the log a moment after the thread
-                        // id arrives; until then there is nothing to open.
-                        tail_lookup_at = std::time::Instant::now();
+                        // id arrives. Attempt every tick rather than backing
+                        // off: the tail starts at the file's end, so any wait
+                        // here is a window in which a record lands unread.
+                        tail_attempts += 1;
                         usage_tail = state
                             .native_session_id
                             .as_deref()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -236,6 +236,8 @@ pub fn run() {
             git::git_create_branch,
             // open-app
             open_app::open_workspace_in,
+            open_app::open_custom_program,
+            open_app::get_program_icon,
             open_app::reveal_in_file_manager,
             // terminal
             terminal::terminal_open,

--- a/src-tauri/src/open_app.rs
+++ b/src-tauri/src/open_app.rs
@@ -1,14 +1,23 @@
 //! Open the workspace folder in an external app (VS Code / Cursor / IntelliJ)
 //! or reveal it in the OS file manager.
 //!
-//! Lean port of the legacy `workspaces/open_app.rs`: preset probing, custom
-//! command targets and OS icon extraction were dropped along with the
-//! settings UI; only the four curated header targets remain.
+//! Lean port of the legacy `workspaces/open_app.rs`: the preset catalog was
+//! trimmed to the four curated header targets, but user-added programs and
+//! their OS icon extraction are back (the header menu's "add program" flow).
 
 use std::path::PathBuf;
 
 #[cfg(not(target_os = "macos"))]
 use std::process::Stdio;
+
+#[cfg(target_os = "macos")]
+use base64::Engine as _;
+#[cfg(target_os = "macos")]
+use std::path::Path;
+#[cfg(target_os = "macos")]
+use std::process::Command;
+#[cfg(target_os = "macos")]
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Expand a leading `~` and reject empty paths.
 pub(crate) fn expand_user_path(path: &str) -> Result<PathBuf, String> {
@@ -232,6 +241,269 @@ pub(crate) async fn open_workspace_in(
     {
         open_with_app_candidates(&app, &args, &path, &target_label)
     }
+}
+
+/// Open a folder (or file) in a user-picked custom program.
+///
+/// Unlike `open_workspace_in` this takes an absolute executable path from the
+/// header menu's "add program" flow and spawns it directly — no whitelist.
+/// That is still not arbitrary command execution: the path must exist on
+/// disk, and nothing shell-like is ever parsed (no `sh -c`, no splitting).
+#[tauri::command]
+pub(crate) async fn open_custom_program(
+    executable_path: String,
+    path: String,
+) -> Result<(), String> {
+    let expanded = expand_user_path(&executable_path)?;
+    let expanded = std::fs::canonicalize(&expanded)
+        .map_err(|error| format!("Failed to resolve executable `{executable_path}`: {error}"))?;
+    if !expanded.is_file() {
+        return Err(format!(
+            "Failed to open custom program: `{}` is not a file",
+            expanded.to_string_lossy()
+        ));
+    }
+    let target_label = format!("program `{}`", expanded.to_string_lossy());
+
+    #[cfg(target_os = "macos")]
+    {
+        // `open <path>` launches a .app bundle; for a bare binary it opens the
+        // containing folder, so bare binaries go through spawn directly.
+        let is_bundle = expanded.extension().is_some_and(|ext| ext.eq_ignore_ascii_case("app"));
+        if is_bundle {
+            let status = tokio::process::Command::new("open")
+                .arg(&expanded)
+                .arg(&path)
+                .status()
+                .await
+                .map_err(|error| format!("Failed to open app ({target_label}): {error}"))?;
+            if status.success() {
+                return Ok(());
+            }
+            return Err(format!(
+                "Failed to open app ({target_label} returned {}).",
+                format_exit_detail(status.code())
+            ));
+        }
+    }
+
+    let mut cmd = std::process::Command::new(&expanded);
+    cmd.arg(&path);
+    // The custom program is typically a GUI app; don't pop a console window.
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::null());
+    cmd.stderr(Stdio::null());
+    cmd.spawn().map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            format!("Failed to open app ({target_label}): program not found")
+        } else {
+            format!("Failed to open app ({target_label}): {error}")
+        }
+    })?;
+    Ok(())
+}
+
+/// Extract a program's OS icon as a PNG data URL (for the header menu rows).
+///
+/// Windows: the shell's associated icon for the executable.
+/// macOS: the icon inside the `.app` bundle when the path points at one.
+/// Linux: not implemented — returns None, and the UI falls back to a letter.
+#[tauri::command]
+pub(crate) async fn get_program_icon(executable_path: String) -> Result<Option<String>, String> {
+    let trimmed = executable_path.trim().to_string();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    tokio::task::spawn_blocking(move || program_icon_sync(&trimmed))
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(windows)]
+fn program_icon_sync(path: &str) -> Option<String> {
+    let path_buf = PathBuf::from(path);
+    if !path_buf.is_file() {
+        return None;
+    }
+    // PowerShell single-quoted literal: a quote is escaped by doubling it.
+    let escaped = path.replace('\'', "''");
+    let script = format!(
+        r#"
+Add-Type -AssemblyName System.Drawing
+$path = '{escaped}'
+if (-not (Test-Path -LiteralPath $path)) {{ exit 1 }}
+$icon = [System.Drawing.Icon]::ExtractAssociatedIcon($path)
+if ($null -eq $icon) {{ exit 2 }}
+$bmp = $icon.ToBitmap()
+$ms = New-Object System.IO.MemoryStream
+$bmp.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png)
+[Convert]::ToBase64String($ms.ToArray())
+"#
+    );
+    let mut cmd = std::process::Command::new("powershell");
+    cmd.args(["-NoProfile", "-NonInteractive", "-Command", &script]);
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::null());
+    let output = cmd.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let encoded = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if encoded.is_empty() {
+        return None;
+    }
+    Some(format!("data:image/png;base64,{encoded}"))
+}
+
+/// Walk up from `path` to the enclosing `.app` bundle, if any.
+#[cfg(target_os = "macos")]
+fn find_app_bundle(path: &Path) -> Option<PathBuf> {
+    let mut current = Some(path);
+    while let Some(candidate) = current {
+        let is_bundle = candidate
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("app"));
+        if is_bundle {
+            return Some(candidate.to_path_buf());
+        }
+        current = candidate.parent();
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn defaults_read(domain: &Path, key: &str) -> Option<String> {
+    let output = Command::new("defaults")
+        .arg("read")
+        .arg(domain.as_os_str())
+        .arg(key)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn resolve_icon_name(bundle_path: &Path) -> String {
+    let info_domain = bundle_path.join("Contents/Info");
+    defaults_read(&info_domain, "CFBundleIconFile")
+        .or_else(|| defaults_read(&info_domain, "CFBundleIconName"))
+        .unwrap_or_else(|| {
+            bundle_path
+                .file_stem()
+                .map(|stem| stem.to_string_lossy().to_string())
+                .unwrap_or_else(|| "AppIcon".to_string())
+        })
+}
+
+#[cfg(target_os = "macos")]
+fn resolve_icon_path(bundle_path: &Path, icon_name: &str) -> Option<PathBuf> {
+    let resources_dir = bundle_path.join("Contents/Resources");
+    if !resources_dir.exists() {
+        return None;
+    }
+    let icon_path = PathBuf::from(icon_name);
+    if icon_path.extension().is_some() {
+        let direct = resources_dir.join(icon_path);
+        if direct.exists() {
+            return Some(direct);
+        }
+    }
+    for candidate in [
+        format!("{icon_name}.icns"),
+        format!("{icon_name}.png"),
+        "AppIcon.icns".to_string(),
+        "AppIcon.png".to_string(),
+        "app.icns".to_string(),
+    ] {
+        let path = resources_dir.join(candidate);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let lowered = icon_name.to_ascii_lowercase();
+    if let Ok(entries) = std::fs::read_dir(resources_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let ext = path
+                .extension()
+                .map(|ext| ext.to_string_lossy().to_ascii_lowercase());
+            if !matches!(ext.as_deref(), Some("icns" | "png")) {
+                continue;
+            }
+            let stem = path
+                .file_stem()
+                .map(|stem| stem.to_string_lossy().to_ascii_lowercase())
+                .unwrap_or_default();
+            if stem == lowered {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn icon_png_bytes(icon_path: &Path) -> Option<Vec<u8>> {
+    let ext = icon_path
+        .extension()
+        .map(|ext| ext.to_string_lossy().to_ascii_lowercase());
+    if matches!(ext.as_deref(), Some("png")) {
+        return std::fs::read(icon_path).ok();
+    }
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or_default();
+    let out_path = std::env::temp_dir().join(format!("ccgui-icon-{ts}.png"));
+    let status = Command::new("sips")
+        .args(["-s", "format", "png"])
+        .arg(icon_path.as_os_str())
+        .arg("--out")
+        .arg(out_path.as_os_str())
+        .status()
+        .ok()?;
+    if !status.success() {
+        let _ = std::fs::remove_file(&out_path);
+        return None;
+    }
+    let bytes = std::fs::read(&out_path).ok();
+    let _ = std::fs::remove_file(&out_path);
+    bytes
+}
+
+#[cfg(target_os = "macos")]
+fn program_icon_sync(path: &str) -> Option<String> {
+    let bundle = find_app_bundle(Path::new(path))?;
+    let icon_name = resolve_icon_name(&bundle);
+    let icon_path = resolve_icon_path(&bundle, &icon_name)?;
+    let png_bytes = icon_png_bytes(&icon_path)?;
+    let encoded = base64::engine::general_purpose::STANDARD.encode(png_bytes);
+    Some(format!("data:image/png;base64,{encoded}"))
+}
+
+#[cfg(all(not(windows), not(target_os = "macos")))]
+fn program_icon_sync(_path: &str) -> Option<String> {
+    None
 }
 
 /// Reveal a local path in the OS file manager (Finder / Explorer / …).

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -579,6 +579,17 @@ struct OpenWorkspaceArgs {
 }
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct OpenCustomProgramArgs {
+    executable_path: String,
+    path: String,
+}
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GetProgramIconArgs {
+    executable_path: String,
+}
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct TerminalOpenArgs {
     id: String,
     cwd: String,
@@ -920,6 +931,14 @@ async fn dispatch(app: &tauri::AppHandle, cmd: &str, raw: Value) -> Result<Value
         "open_workspace_in" => {
             let a: OpenWorkspaceArgs = parse_args(&raw)?;
             ser(crate::open_app::open_workspace_in(a.path, a.app, a.args).await)
+        }
+        "open_custom_program" => {
+            let a: OpenCustomProgramArgs = parse_args(&raw)?;
+            ser(crate::open_app::open_custom_program(a.executable_path, a.path).await)
+        }
+        "get_program_icon" => {
+            let a: GetProgramIconArgs = parse_args(&raw)?;
+            ser(crate::open_app::get_program_icon(a.executable_path).await)
         }
         "reveal_in_file_manager" => {
             let a: PathArgs = parse_args(&raw)?;

--- a/src/components/dialogs.tsx
+++ b/src/components/dialogs.tsx
@@ -30,11 +30,14 @@ export function ModalShell({
   children,
   onClose,
   className,
+  label,
 }: {
   children: ReactNode;
   onClose: () => void;
   /** Panel sizing override; defaults to the compact w-80 prompt size. */
   className?: string;
+  /** Accessible title for the dialog (or render a Heading slot="title"). */
+  label?: string;
 }) {
   return (
     <ModalOverlay
@@ -51,7 +54,9 @@ export function ModalShell({
           className,
         )}
       >
-        <Dialog className="outline-none">{children}</Dialog>
+        <Dialog aria-label={label} className="outline-none">
+          {children}
+        </Dialog>
       </Modal>
     </ModalOverlay>
   );

--- a/src/features/open-app/HeaderOpenActions.test.tsx
+++ b/src/features/open-app/HeaderOpenActions.test.tsx
@@ -1,0 +1,183 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  openWorkspaceIn: vi.fn(),
+  openCustomProgram: vi.fn(),
+  getProgramIcon: vi.fn().mockResolvedValue("data:image/png;base64,ICON"),
+  revealInFileManager: vi.fn(),
+}));
+vi.mock("@/lib/ipc", () => ({
+  ipc: {
+    openWorkspaceIn: mocks.openWorkspaceIn,
+    openCustomProgram: mocks.openCustomProgram,
+    getProgramIcon: mocks.getProgramIcon,
+    revealInFileManager: mocks.revealInFileManager,
+  },
+}));
+// The add-program dialog picks the executable via the platform helper; the
+// test types a path instead, so the picker must never be reached.
+vi.mock("@/lib/platform", () => ({
+  pickFile: vi.fn().mockResolvedValue(null),
+}));
+
+import "@/lib/i18n";
+import { HeaderOpenActions } from "./HeaderOpenActions";
+import {
+  CUSTOM_APPS_KEY,
+  readCustomApps,
+  writeCustomApps,
+  writePinnedIds,
+} from "./open-app";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function buttonByText(text: string): HTMLButtonElement | null {
+  return [...document.querySelectorAll<HTMLButtonElement>("button")].find((b) =>
+    b.textContent?.includes(text),
+  ) ?? null;
+}
+
+function inputByLabel(label: string): HTMLInputElement | null {
+  const labelNode = [...document.querySelectorAll<HTMLLabelElement>("label")].find(
+    (l) => l.textContent?.trim() === label,
+  );
+  if (labelNode?.htmlFor) {
+    return document.getElementById(labelNode.htmlFor) as HTMLInputElement | null;
+  }
+  return [...document.querySelectorAll<HTMLInputElement>("input")].find(
+    (input) => input.placeholder === label,
+  ) ?? null;
+}
+
+/** Type into a controlled input the way React sees it (native setter +
+ *  bubbling input event). */
+function typeInto(input: HTMLInputElement, value: string) {
+  Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(
+    input,
+    value,
+  );
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("HeaderOpenActions add-program", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    localStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    document.body.querySelectorAll("[data-react-aria-top-layer]").forEach((node) => node.remove());
+  });
+
+  async function openMenu() {
+    await act(async () => {
+      root.render(<HeaderOpenActions workspacePath="/workspace" />);
+    });
+    // The ellipsis trigger is the last header button; clicking it opens the menu.
+    await act(async () => {
+      const buttons = document.querySelectorAll<HTMLButtonElement>("button");
+      buttons.item(buttons.length - 1).click();
+    });
+  }
+
+  it("adds a custom program: menu row appears, is pinned to the header, persisted", async () => {
+    await openMenu();
+
+    const addButton = buttonByText("添加程序");
+    expect(addButton).toBeTruthy();
+    await act(async () => {
+      addButton!.click();
+    });
+
+    // The dialog renders two fields: 名称 and 可执行文件.
+    const nameInput = inputByLabel("名称");
+    const pathInput = inputByLabel("可执行文件");
+    expect(nameInput).toBeTruthy();
+    expect(pathInput).toBeTruthy();
+    await act(async () => {
+      typeInto(nameInput!, "Notepad++");
+      typeInto(pathInput!, "C:\\Program Files\\Notepad++\\notepad++.exe");
+    });
+
+    const confirm = buttonByText("确认");
+    expect(confirm!.disabled).toBe(false);
+    await act(async () => {
+      confirm!.click();
+    });
+
+    // Adding closes the menu; reopen it to see the new row.
+    await act(async () => {
+      const buttons = document.querySelectorAll<HTMLButtonElement>("button");
+      buttons.item(buttons.length - 1).click();
+    });
+    const menuRow = buttonByText("Notepad++");
+    expect(menuRow).toBeTruthy();
+
+    // The OS-extracted icon is fetched and rendered in the row (not a letter).
+    await act(async () => {});
+    expect(mocks.getProgramIcon).toHaveBeenCalledWith(
+      "C:\\Program Files\\Notepad++\\notepad++.exe",
+    );
+    expect(menuRow!.querySelector("img")?.getAttribute("src")).toBe(
+      "data:image/png;base64,ICON",
+    );
+
+    // The entry is persisted with the typed label/path.
+    const apps = readCustomApps();
+    expect(apps).toHaveLength(1);
+    expect(apps[0].label).toBe("Notepad++");
+    expect(apps[0].path).toBe("C:\\Program Files\\Notepad++\\notepad++.exe");
+    expect(JSON.parse(localStorage.getItem(CUSTOM_APPS_KEY) ?? "[]")).toHaveLength(1);
+
+    // Selecting the row launches the custom program with the workspace path.
+    await act(async () => {
+      menuRow!.click();
+    });
+    expect(mocks.openCustomProgram).toHaveBeenCalledWith(
+      apps[0].path,
+      expect.stringMatching(/workspace/),
+    );
+  });
+
+  it("removing a custom program drops it from the menu and unpins it", async () => {
+    // Seed one program directly (what adding produces, minus the dialog).
+    await openMenu();
+    await act(async () => {
+      writeCustomApps([{ id: "custom:seed", label: "SeedApp", path: "/opt/seed/seed" }]);
+      writePinnedIds(["vscode", "terminal", "custom:seed"]);
+    });
+    // Re-render so the store picks up the seeded values.
+    await act(async () => {
+      root.unmount();
+      root = createRoot(container);
+      root.render(<HeaderOpenActions workspacePath="/workspace" />);
+    });
+
+    // The delete affordance lives inside the menu; open it first.
+    await act(async () => {
+      const buttons = document.querySelectorAll<HTMLButtonElement>("button");
+      buttons.item(buttons.length - 1).click();
+    });
+    const removeButton = [...document.querySelectorAll<HTMLButtonElement>("button")].find(
+      (b) => b.getAttribute("aria-label") === "删除程序",
+    );
+    expect(removeButton).toBeTruthy();
+    await act(async () => {
+      removeButton!.click();
+    });
+
+    expect(readCustomApps()).toHaveLength(0);
+    expect(JSON.parse(localStorage.getItem(CUSTOM_APPS_KEY) ?? "[]")).toHaveLength(0);
+  });
+});

--- a/src/features/open-app/HeaderOpenActions.tsx
+++ b/src/features/open-app/HeaderOpenActions.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Button as AriaButton,
@@ -7,23 +7,34 @@ import {
   Popover as AriaPopover,
 } from "react-aria-components";
 import Ellipsis from "lucide-react/dist/esm/icons/ellipsis";
+import Plus from "lucide-react/dist/esm/icons/plus";
 import SquareTerminal from "lucide-react/dist/esm/icons/square-terminal";
+import Trash2 from "lucide-react/dist/esm/icons/trash-2";
+import { Button } from "@/components/base/buttons/button";
 import { Checkbox } from "@/components/base/checkbox/checkbox";
 import { menuPopoverSurface } from "@/components/base/dropdown/menu-styles";
+import { Input } from "@/components/base/input/input";
+import { ModalShell } from "@/components/dialogs";
 import { useFilesStore } from "@/features/files/store";
 import { useTerminalStore } from "@/features/terminal/store";
+import { pickFile } from "@/lib/platform";
 import { cx } from "@/utils/cx";
 import { usePopoverState } from "@/utils/use-dismiss-on-outside-press";
 import {
   OPEN_APP_ICONS,
   OPEN_APP_TARGETS,
   TERMINAL_ACTION_ID,
+  extractCustomAppIcon,
+  openCustomProgram,
   openPathInTarget,
+  readCustomApps,
   readPinnedIds,
   readSelectedOpenAppId,
   resolveOpenAppPath,
+  writeCustomApps,
   writePinnedIds,
   writeSelectedOpenAppId,
+  type CustomApp,
   type OpenAppTarget,
 } from "./open-app";
 
@@ -31,7 +42,8 @@ import {
  * Titlebar cluster migrated from the legacy MainHeader: pinned "open in"
  * targets, the terminal dock toggle, and the "更多" menu holding every open
  * target plus the terminal row, each with a pin checkbox controlling header
- * visibility.
+ * visibility. The menu footer can add a custom program (executable path the
+ * backend spawns directly), which then appears as a normal target row.
  */
 
 const ICON_BUTTON_CLASSES = cx(
@@ -46,6 +58,101 @@ const POPOVER_CLASSES = menuPopoverSurface({
   padding: "p-1.5",
 });
 
+/** Custom programs carry an OS icon data URL; presets use the catalog. */
+function TargetIcon({ target }: { target: { id: string; label: string; icon?: string | null } }) {
+  const src = target.icon ?? OPEN_APP_ICONS[target.id];
+  if (src) {
+    return <img src={src} alt="" aria-hidden className="size-4 shrink-0" />;
+  }
+  return (
+    <span
+      aria-hidden
+      className="flex size-4 shrink-0 items-center justify-center rounded-[3px] bg-background-secondary-hover text-caption-1-semibold text-foreground-icon-primary"
+    >
+      {target.label.trim().charAt(0).toUpperCase() || "?"}
+    </span>
+  );
+}
+
+/**
+ * Two-field "add a program" dialog: display name + executable path. The path
+ * comes from the native file picker on desktop and free text on web.
+ */
+function AddProgramDialog({
+  onAdd,
+  onCancel,
+}: {
+  onAdd: (app: CustomApp) => void;
+  onCancel: () => void;
+}) {
+  const { t } = useTranslation();
+  const [label, setLabel] = useState("");
+  const [path, setPath] = useState("");
+
+  const pickExecutable = useCallback(() => {
+    void pickFile(t("openApp.addProgram.pickExecutable"), []).then((picked) => {
+      if (picked) setPath(picked);
+    });
+  }, [t]);
+
+  const trimmedLabel = label.trim();
+  const trimmedPath = path.trim();
+  const canSubmit = trimmedLabel.length > 0 && trimmedPath.length > 0;
+
+  const submit = useCallback(() => {
+    if (!canSubmit) return;
+    onAdd({
+      // Suffix distinguishes custom ids from the preset catalog ids.
+      id: `custom:${Date.now().toString(36)}:${trimmedPath}`,
+      label: trimmedLabel,
+      path: trimmedPath,
+    });
+  }, [canSubmit, onAdd, trimmedLabel, trimmedPath]);
+
+  return (
+    <ModalShell onClose={onCancel} label={t("openApp.addProgram.add")}>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          submit();
+        }}
+        className="flex flex-col gap-3"
+      >
+        <Input
+          autoFocus
+          label={t("openApp.addProgram.name")}
+          placeholder={t("openApp.addProgram.namePlaceholder")}
+          value={label}
+          onChange={setLabel}
+          size="small"
+        />
+        <div className="flex items-end gap-2">
+          <div className="min-w-0 flex-1">
+            <Input
+              label={t("openApp.addProgram.executable")}
+              placeholder={t("openApp.addProgram.executablePlaceholder")}
+              value={path}
+              onChange={setPath}
+              size="small"
+            />
+          </div>
+          <Button variant="secondary" size="small" onClick={pickExecutable} type="button">
+            {t("openApp.addProgram.browse")}
+          </Button>
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button variant="secondary" size="small" onClick={onCancel}>
+            {t("common.cancel")}
+          </Button>
+          <Button variant="primary" size="small" type="submit" disabled={!canSubmit}>
+            {t("common.confirm")}
+          </Button>
+        </div>
+      </form>
+    </ModalShell>
+  );
+}
+
 export function HeaderOpenActions({ workspacePath }: { workspacePath: string }) {
   const { t } = useTranslation();
   // Editors open the file shown in the active editor tab; Finder always
@@ -55,6 +162,8 @@ export function HeaderOpenActions({ workspacePath }: { workspacePath: string }) 
   const toggleTerminal = useTerminalStore((s) => s.toggle);
   const [pinnedIds, setPinnedIds] = useState(readPinnedIds);
   const [selectedId, setSelectedId] = useState(readSelectedOpenAppId);
+  const [customApps, setCustomApps] = useState<CustomApp[]>(readCustomApps);
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
   const {
     isOpen: menuOpen,
     triggerRef,
@@ -64,10 +173,14 @@ export function HeaderOpenActions({ workspacePath }: { workspacePath: string }) 
   } = usePopoverState();
 
   const openTarget = useCallback(
-    async (target: OpenAppTarget) => {
+    async (target: OpenAppTarget | CustomApp) => {
       const path = resolveOpenAppPath(target, { workspacePath, activeFilePath });
       try {
-        await openPathInTarget(path, target);
+        if ("path" in target) {
+          await openCustomProgram(path, target);
+        } else {
+          await openPathInTarget(path, target);
+        }
       } catch {
         // Silent by design: the target app is typically just not installed,
         // and the header cluster has no error surface worth interrupting for.
@@ -77,7 +190,7 @@ export function HeaderOpenActions({ workspacePath }: { workspacePath: string }) 
   );
 
   const handleSelectTarget = useCallback(
-    (target: OpenAppTarget) => {
+    (target: OpenAppTarget | CustomApp) => {
       setSelectedId(target.id);
       writeSelectedOpenAppId(target.id);
       closeMenu();
@@ -94,12 +207,113 @@ export function HeaderOpenActions({ workspacePath }: { workspacePath: string }) 
     });
   }, []);
 
+  const addCustomApp = useCallback(
+    (app: CustomApp) => {
+      setCustomApps((prev) => {
+        const next = [...prev, app];
+        writeCustomApps(next);
+        return next;
+      });
+      // New programs appear in the header right away, like the presets do by
+      // default.
+      setPinnedIds((prev) => {
+        const next = prev.includes(app.id) ? prev : [...prev, app.id];
+        writePinnedIds(next);
+        return next;
+      });
+      setAddDialogOpen(false);
+    },
+    [],
+  );
+
+  const removeCustomApp = useCallback((id: string) => {
+    setCustomApps((prev) => {
+      const next = prev.filter((app) => app.id !== id);
+      writeCustomApps(next);
+      return next;
+    });
+    // Drop the pin so the header stops referencing a program that is gone.
+    setPinnedIds((prev) => {
+      const next = prev.filter((p) => p !== id);
+      writePinnedIds(next);
+      return next;
+    });
+  }, []);
+
+  // Extract OS icons for programs that don't have one yet (once per entry;
+  // a failed extraction persists `null` so it is not retried every mount).
+  useEffect(() => {
+    const pending = customApps.filter((app) => app.icon === undefined);
+    if (pending.length === 0) return;
+    let cancelled = false;
+    void Promise.all(
+      pending.map(async (app) => ({ id: app.id, icon: await extractCustomAppIcon(app) })),
+    ).then((results) => {
+      if (cancelled) return;
+      const iconById = new Map(results.map((result) => [result.id, result.icon]));
+      setCustomApps((prev) => {
+        const next = prev.map((app) =>
+          app.icon === undefined && iconById.has(app.id)
+            ? { ...app, icon: iconById.get(app.id) ?? null }
+            : app,
+        );
+        writeCustomApps(next);
+        return next;
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [customApps]);
+
   // Set form of pinnedIds: lookups below run once per target per render.
   const pinnedIdSet = useMemo(() => new Set(pinnedIds), [pinnedIds]);
 
   const terminalPinned = pinnedIdSet.has(TERMINAL_ACTION_ID);
   const terminalLabel = t("openApp.terminal");
   const showInHeaderLabel = t("openApp.showInHeader");
+
+  const renderTargetRow = (target: OpenAppTarget | CustomApp) => {
+    const isCustom = "path" in target;
+    return (
+      <div
+        key={target.id}
+        className={cx(
+          "flex items-center gap-1 rounded-2lg pr-1.5",
+          target.id === selectedId && "bg-background-secondary-default",
+          // External-app targets are desktop-only; mobile keeps the
+          // terminal row below.
+          "max-md:hidden",
+        )}
+      >
+        <button
+          type="button"
+          onClick={() => handleSelectTarget(target)}
+          className="flex min-w-0 flex-1 cursor-pointer items-center gap-2.5 rounded-2lg p-2 text-left outline-none transition-colors hover:bg-background-primary-hover focus-visible:bg-background-primary-hover"
+        >
+          <TargetIcon target={target} />
+          <span className="truncate text-body-medium text-text-primary">{target.label}</span>
+        </button>
+        {isCustom && (
+          <button
+            type="button"
+            title={t("openApp.removeProgram")}
+            aria-label={t("openApp.removeProgram")}
+            onClick={() => removeCustomApp(target.id)}
+            className="flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-md text-foreground-icon-secondary outline-none transition-colors hover:bg-background-primary-hover hover:text-foreground-icon-primary focus-visible:bg-background-primary-hover"
+          >
+            <Trash2 className="size-3.5" aria-hidden />
+          </button>
+        )}
+        <Checkbox
+          size="sm"
+          isSelected={pinnedIdSet.has(target.id)}
+          onChange={() => togglePinned(target.id)}
+          aria-label={showInHeaderLabel}
+        />
+      </div>
+    );
+  };
 
   return (
     <div className="flex items-center gap-0.5 px-1.5">
@@ -118,6 +332,21 @@ export function HeaderOpenActions({ workspacePath }: { workspacePath: string }) 
           </button>,
         ];
       })}
+      {customApps.flatMap((app) => {
+        if (!pinnedIdSet.has(app.id)) return [];
+        return [
+          <button
+            key={app.id}
+            type="button"
+            title={t("openApp.openIn", { target: app.label })}
+            aria-label={t("openApp.openIn", { target: app.label })}
+            onClick={() => void openTarget(app)}
+            className={cx(ICON_BUTTON_CLASSES, "max-md:hidden")}
+          >
+            <TargetIcon target={app} />
+          </button>,
+        ];
+      })}
       {terminalPinned && (
         <button
           type="button"
@@ -133,10 +362,7 @@ export function HeaderOpenActions({ workspacePath }: { workspacePath: string }) 
           <SquareTerminal className="size-4" aria-hidden />
         </button>
       )}
-      <AriaDialogTrigger
-        isOpen={menuOpen}
-        onOpenChange={setOpen}
-      >
+      <AriaDialogTrigger isOpen={menuOpen} onOpenChange={setOpen}>
         <AriaButton
           ref={triggerRef}
           aria-label={t("openApp.more")}
@@ -153,40 +379,8 @@ export function HeaderOpenActions({ workspacePath }: { workspacePath: string }) 
         >
           <AriaDialog aria-label={t("openApp.more")} className="outline-none">
             <div className="flex w-full flex-col gap-0.5">
-              {OPEN_APP_TARGETS.map((target) => (
-                <div
-                  key={target.id}
-                  className={cx(
-                    "flex items-center gap-1 rounded-2lg pr-1.5",
-                    target.id === selectedId && "bg-background-secondary-default",
-                    // External-app targets are desktop-only; mobile keeps the
-                    // terminal row below.
-                    "max-md:hidden",
-                  )}
-                >
-                  <button
-                    type="button"
-                    onClick={() => handleSelectTarget(target)}
-                    className="flex min-w-0 flex-1 cursor-pointer items-center gap-2.5 rounded-2lg p-2 text-left outline-none transition-colors hover:bg-background-primary-hover focus-visible:bg-background-primary-hover"
-                  >
-                    <img
-                      src={OPEN_APP_ICONS[target.id]}
-                      alt=""
-                      aria-hidden
-                      className="size-4 shrink-0"
-                    />
-                    <span className="truncate text-body-medium text-text-primary">
-                      {target.label}
-                    </span>
-                  </button>
-                  <Checkbox
-                    size="sm"
-                    isSelected={pinnedIdSet.has(target.id)}
-                    onChange={() => togglePinned(target.id)}
-                    aria-label={showInHeaderLabel}
-                  />
-                </div>
-              ))}
+              {OPEN_APP_TARGETS.map((target) => renderTargetRow(target))}
+              {customApps.map((app) => renderTargetRow(app))}
               <div className="flex items-center gap-1 rounded-2lg pr-1.5">
                 <button
                   type="button"
@@ -211,10 +405,25 @@ export function HeaderOpenActions({ workspacePath }: { workspacePath: string }) 
                   aria-label={showInHeaderLabel}
                 />
               </div>
+              <div className="my-0.5 h-px bg-border-secondary" aria-hidden />
+              <button
+                type="button"
+                onClick={() => {
+                  setAddDialogOpen(true);
+                  closeMenu();
+                }}
+                className="flex w-full cursor-pointer items-center gap-2.5 rounded-2lg p-2 text-left outline-none transition-colors hover:bg-background-primary-hover focus-visible:bg-background-primary-hover"
+              >
+                <Plus className="size-4 shrink-0 text-foreground-icon-secondary" aria-hidden />
+                <span className="truncate text-body-medium text-text-primary">
+                  {t("openApp.addProgram.add")}
+                </span>
+              </button>
             </div>
           </AriaDialog>
         </AriaPopover>
       </AriaDialogTrigger>
+      {addDialogOpen && <AddProgramDialog onAdd={addCustomApp} onCancel={() => setAddDialogOpen(false)} />}
     </div>
   );
 }

--- a/src/features/open-app/open-app.ts
+++ b/src/features/open-app/open-app.ts
@@ -36,13 +36,14 @@ export const OPEN_APP_ICONS: Record<string, string> = {
 
 /**
  * Which path a target receives: the file manager always gets the workspace
- * folder; editors prefer the file currently open in the files panel.
+ * folder; editors (and custom programs) prefer the file currently open in
+ * the files panel.
  */
 export function resolveOpenAppPath(
-  target: Pick<OpenAppTarget, "kind">,
+  target: Pick<OpenAppTarget, "kind"> | CustomApp,
   options: { workspacePath: string; activeFilePath?: string | null },
 ): string {
-  if (target.kind === "finder") return options.workspacePath;
+  if ("kind" in target && target.kind === "finder") return options.workspacePath;
   return options.activeFilePath?.trim() || options.workspacePath;
 }
 
@@ -53,6 +54,62 @@ export async function openPathInTarget(path: string, target: OpenAppTarget): Pro
   }
   if (!target.appName) return;
   await ipc.openWorkspaceIn(path, { appName: target.appName });
+}
+
+/** Launch a custom program entry at `path` with the workspace path appended. */
+export async function openCustomProgram(path: string, app: CustomApp): Promise<void> {
+  await ipc.openCustomProgram(app.path, path);
+}
+
+// ---------- user-added custom programs (header menu "添加程序") ----------
+
+export type CustomApp = {
+  id: string;
+  /** Display name in the menu (user-provided; falls back to the file name). */
+  label: string;
+  /** Absolute path of the executable (or macOS .app bundle). */
+  path: string;
+  /**
+   * OS-extracted icon as a PNG data URL. `undefined` = not extracted yet,
+   * `null` = extraction ran and found nothing (so we don't retry).
+   */
+  icon?: string | null;
+};
+
+export const CUSTOM_APPS_KEY = "ccgui-next.openWorkspaceCustomApps";
+
+export function readCustomApps(): CustomApp[] {
+  return (
+    readStoredJson<CustomApp[]>(CUSTOM_APPS_KEY, (stored) =>
+      Array.isArray(stored)
+        ? stored.flatMap((entry): CustomApp[] => {
+            if (
+              typeof entry !== "object" ||
+              entry === null ||
+              typeof (entry as CustomApp).id !== "string" ||
+              typeof (entry as CustomApp).label !== "string" ||
+              typeof (entry as CustomApp).path !== "string"
+            ) {
+              return [];
+            }
+            const raw = entry as CustomApp;
+            const icon =
+              typeof raw.icon === "string" ? raw.icon : raw.icon === null ? null : undefined;
+            return [{ id: raw.id, label: raw.label, path: raw.path, icon }];
+          })
+        : null,
+    ) ?? []
+  );
+}
+
+export function writeCustomApps(apps: CustomApp[]): void {
+  writeStored(CUSTOM_APPS_KEY, JSON.stringify(apps));
+}
+
+/** Extract the icon for an app that has not been probed yet (failures → null). */
+export async function extractCustomAppIcon(app: CustomApp): Promise<string | null> {
+  if (app.icon !== undefined) return app.icon;
+  return ipc.getProgramIcon(app.path).catch(() => null);
 }
 
 // ---------- header pinning / selection persistence (localStorage) ----------

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -608,6 +608,16 @@ export const en: Messages = {
     showInHeader: "Show in header",
     collapsePanel: "Collapse sidebar",
     expandPanel: "Expand sidebar",
+    addProgram: {
+      add: "Add program",
+      name: "Name",
+      namePlaceholder: "e.g. Notepad++",
+      executable: "Executable",
+      executablePlaceholder: "/path/to/program or browse",
+      browse: "Browse…",
+      pickExecutable: "Select the program executable",
+    },
+    removeProgram: "Remove program",
   },
   changelog: {
     title: "Release Notes",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -577,6 +577,16 @@ export const zh = {
     showInHeader: "在顶栏显示",
     collapsePanel: "收起侧边栏",
     expandPanel: "展开侧边栏",
+    addProgram: {
+      add: "添加程序",
+      name: "名称",
+      namePlaceholder: "例如 Notepad++",
+      executable: "可执行文件",
+      executablePlaceholder: "程序路径或点击浏览",
+      browse: "浏览…",
+      pickExecutable: "选择程序可执行文件",
+    },
+    removeProgram: "删除程序",
   },
   changelog: {
     title: "版本更新",

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -635,6 +635,12 @@ export const ipc = {
   // open-app
   openWorkspaceIn: (path: string, options: { appName: string; args?: string[] }) =>
     invoke<void>("open_workspace_in", { path, app: options.appName, args: options.args ?? [] }),
+  /** Launch a user-picked custom program with the workspace path as argument. */
+  openCustomProgram: (executablePath: string, path: string) =>
+    invoke<void>("open_custom_program", { executablePath, path }),
+  /** OS icon for a program executable as a PNG data URL (null when none). */
+  getProgramIcon: (executablePath: string) =>
+    invoke<string | null>("get_program_icon", { executablePath }),
   revealInFileManager: (path: string) =>
     invoke<void>("reveal_in_file_manager", { path }),
   // metrics


### PR DESCRIPTION
本 PR 包含两项改动：

1. **feat(open-app)**：顶栏「更多」菜单支持添加自定义程序，并提取其系统图标。
2. **fix(usage)**：codex 用量台账从 rollout **末尾**起算，修正启动即虚增 100M 的问题。

---

## 一、feat(open-app)：菜单添加自定义程序 + 图标提取

### 功能

顶栏「更多」菜单新增**添加程序**：从本机选取任意可执行文件，作为一个「打开方式」目标加入菜单与顶栏（与 VS Code / Cursor / Finder / IntelliJ 并列，可钉选、可删除）。

### 改动

**前端** `src/features/open-app/`

- `open-app.ts`：新增 `CustomApp { id, label, path, icon? }` 与 localStorage 读写（`ccgui-next.openWorkspaceCustomApps`），读取时逐条校验并归一化。
- `HeaderOpenActions.tsx`：菜单底部新增「添加程序」按钮（分隔线下方、紧邻终端行）；对话框收集名称 + 可执行文件路径（复用现有 `Input` / `ModalShell`，路径走 `pickFile` 原生选择器，web 模式回落手输）；自定义程序与预设目标共用同一套行渲染（选择、钉选、删除）。
- 行图标优先使用程序真实图标，提取失败时回落首字母徽章。

**IPC** `src/lib/ipc.ts`：`openCustomProgram`、`getProgramIcon`。

**后端** `src-tauri/src/`

- `open_app.rs`
  - `open_custom_program(executable_path, path)`：把用户选取的可执行文件路径规范化（`~` 展开 + canonicalize）并校验为**已存在的文件**后直接拉起；不解析 shell、不拼命令，非任意命令执行；macOS 上 `.app` 走 `open`。
  - `get_program_icon(executable_path)`：返回 PNG data URL。Windows 走 `ExtractAssociatedIcon`（PowerShell，隐藏控制台窗口）；macOS 解析 `.app` 包内 `Info.plist` 图标并经 `sips` 转 PNG；Linux 暂返回 `None`（UI 回落首字母）。
- `lib.rs` / `web.rs`：注册两个命令并补齐 web-access 桥接。

### 回归（open-app）

`src/features/open-app/HeaderOpenActions.test.tsx`（新增）：

- 添加程序 → 菜单出现该行 → `readCustomApps()` 与 localStorage 落盘一致 → 选中行触发 `openCustomProgram(path, workspacePath)`；
- 程序图标经 `getProgramIcon` 取回后以 `<img>` 渲染（非首字母）；
- 删除程序 → 落盘清空并解除顶栏钉选。

`tsc --noEmit` 干净；`cargo check` 干净；真实桌面应用冒烟通过（顶栏渲染出选取程序的真实图标）。

---

## 二、fix(usage)：codex rollout 尾部记账

### 问题

用量页的「Token 累计」在 codex **刚启动、任务还没开始**时就跳涨 100M。

`UsageTail` 以 `offset: 0` 打开 codex 的 rollout 日志，但 `codex exec resume` 是**追加**写回该线程第一次创建的那个文件——字节 0 处是整条线程的全部历史。于是每次启动都把历史里每一条 `token_usage_record` 当作本次运行的新报告重新入账。

本机实测（线程 `01a08ac3`，47MB rollout）：

| 文件内 `token_usage_record` | 累加 in+out | 台账中该组合的副本数 |
|---|---|---|
| 771 条 | 102,079,195 | 6 份（逐字节相同） |

台账记了 616M，实际只花了 106M。另一条会话 `01a08ff9` 复现了同一机制的小号版本：某次 resume 在 4 毫秒内写入 42 行，正好等于该 rollout 里时间戳早于那一刻的 42 条记录。

### 改动

`src-tauri/src/engine/codex_usage.rs`

- tail 锚定到**文件末尾**，只上报 CLI 从此刻起追加的内容。写了一半的尾行解析失败会被跳过，所以从行中间起算没有代价。

`src-tauri/src/engine/mod.rs`

- 打开 tail 的重试原有 1 秒退避。锚点改成 EOF 之后，任何等待都是一个「记录落盘却读不到」的窗口，所以改为**每个 tick 都尝试**，并以次数封顶（20 次 ≈ 10s）——每次尝试都要遍历 `sessions/**`，若某次运行的 CODEX_HOME 并非正在被写入的那个，无界重试会整轮持续遍历。
- 原注释称「resumed id 会重放昨天的记录」，描述的机制是错的（重放源于 offset，不是 id）。改为陈述真实理由：预置 id 可能指向 CLI 已不再写入的线程，tail 它会**漏掉**本次运行的报告。

### 回归（usage）

`history_already_in_the_rollout_is_not_reported`：文件预置两条记录 → `poll()` 必须为空 → 追加一条 → 只报这一条。

`cargo test --lib`：230 passed, 0 failed。CI 全绿。
