### PR TITLE
fix(codex): 自定义 Codex 配置目录，历史和安装不再写死 ~/.codex

### DIFF
--- a/src-tauri/src/cli_lifecycle.rs
+++ b/src-tauri/src/cli_lifecycle.rs
@@ -116,7 +116,7 @@ fn claude_update_kind(bin: &str) -> &'static str {
 }
 
 fn update_kind(engine: &str, bin: &str) -> Option<&'static str> {
-    if engine == "claude" {
+    if engine == "claude" || engine == "codex" {
         return Some(claude_update_kind(bin));
     }
     npm_package(engine).map(|_| "npm")
@@ -224,7 +224,7 @@ pub async fn cli_update_plan(engine: String) -> Result<CliUpdatePlan, String> {
             (std::iter::once(program).chain(args).collect(), Vec::new())
         }
         Some("native") => {
-            let (program, args) = claude_native_argv();
+            let (program, args) = native_install_argv(&engine);
             (
                 std::iter::once(program.to_string())
                     .chain(args.iter().map(|a| a.to_string()))
@@ -261,7 +261,7 @@ pub async fn cli_update(
             let package = npm_package(&engine).expect("npm kind implies package");
             run_npm_install(package, &reporter).await?;
         }
-        Some("native") => run_claude_native_install(&reporter).await?,
+        Some("native") => run_native_install(&engine, &reporter).await?,
         _ => return Err(format!("{engine} 不支持一键安装/更新。")),
     }
     // Fresh local version after the install.
@@ -288,6 +288,15 @@ fn npm_install_argv(package: &str) -> (String, Vec<String>) {
     (npm, args)
 }
 
+/// Official installer argv for a native-channel engine (claude / codex).
+fn native_install_argv(engine: &str) -> (&'static str, Vec<&'static str>) {
+    if engine == "codex" {
+        codex_native_argv()
+    } else {
+        claude_native_argv()
+    }
+}
+
 /// Claude native-channel argv (official install script; handles both fresh
 /// installs and in-place updates).
 fn claude_native_argv() -> (&'static str, Vec<&'static str>) {
@@ -306,6 +315,28 @@ fn claude_native_argv() -> (&'static str, Vec<&'static str>) {
         (
             "bash",
             vec!["-lc", "curl -fsSL https://claude.ai/install.sh | bash"],
+        )
+    }
+}
+
+/// Codex standalone installer: updates `~/.local/bin/codex` (or
+/// `$CODEX_INSTALL_DIR`) in place instead of forcing an npm global copy.
+fn codex_native_argv() -> (&'static str, Vec<&'static str>) {
+    if cfg!(target_os = "windows") {
+        (
+            "powershell",
+            vec![
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                "irm https://chatgpt.com/codex/install.ps1 | iex",
+            ],
+        )
+    } else {
+        (
+            "bash",
+            vec!["-lc", "curl -fsSL https://chatgpt.com/codex/install.sh | bash"],
         )
     }
 }
@@ -335,10 +366,10 @@ async fn run_npm_install(package: &str, reporter: &ProgressReporter) -> Result<(
     Ok(())
 }
 
-/// Claude native channel: the official install script handles both fresh
+/// Native channel: the official install script handles both fresh
 /// installs and in-place updates.
-async fn run_claude_native_install(reporter: &ProgressReporter) -> Result<(), String> {
-    let (program, args) = claude_native_argv();
+async fn run_native_install(engine: &str, reporter: &ProgressReporter) -> Result<(), String> {
+    let (program, args) = native_install_argv(engine);
     let mut command = Command::new(program);
     command.args(args);
     let output = run_streaming(&mut command, INSTALL_TIMEOUT, reporter)
@@ -675,9 +706,18 @@ mod tests {
         assert_eq!(update_kind("dsh", "/usr/local/bin/dsh"), Some("npm"));
         // grok has no lifecycle action.
         assert_eq!(update_kind("grok", "/usr/local/bin/grok"), None);
-        // claude: a node_modules path means the npm distribution.
+        // claude / codex: a node_modules path means the npm distribution;
+        // anything else uses the official standalone installer.
         assert_eq!(
             update_kind("claude", "/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js"),
+            Some("npm")
+        );
+        assert_eq!(update_kind("codex", "/usr/local/bin/codex"), Some("native"));
+        assert_eq!(
+            update_kind(
+                "codex",
+                "/usr/local/lib/node_modules/@openai/codex/bin/codex.js"
+            ),
             Some("npm")
         );
     }

--- a/src-tauri/src/engine/codex_provider_env.rs
+++ b/src-tauri/src/engine/codex_provider_env.rs
@@ -26,7 +26,7 @@ done
 "#;
 
 pub(crate) async fn apply(command: &mut Command) {
-    let config_path = crate::engine::engine_home(Some("CODEX_HOME"), ".codex").join("config.toml");
+    let config_path = crate::engine::codex_home().join("config.toml");
     let Ok(contents) = tokio::fs::read_to_string(config_path).await else {
         return;
     };

--- a/src-tauri/src/engine/codex_usage.rs
+++ b/src-tauri/src/engine/codex_usage.rs
@@ -36,7 +36,7 @@ impl UsageTail {
     /// appends from here on. None until the CLI has created the file, so
     /// callers retry while the run streams.
     pub fn open(thread_id: &str) -> Option<Self> {
-        let home = crate::engine::engine_home(Some("CODEX_HOME"), ".codex");
+        let home = crate::engine::codex_home();
         Self::open_in(&home, thread_id)
     }
 

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -457,6 +457,28 @@ pub(crate) fn engine_home(env_key: Option<&str>, default_dir: &str) -> PathBuf {
     fallback_home().join(default_dir)
 }
 
+/// Codex config/session home. Settings override wins in production so CLI
+/// 管理's directory is what history, official config, and `codex exec` all
+/// read — not a leftover `~/.codex` default. Tests keep using `CODEX_HOME`
+/// / `HOME/.codex` so HomeGuard scratch dirs stay isolated.
+pub(crate) fn codex_home() -> PathBuf {
+    #[cfg(not(test))]
+    if let Some(path) = settings_codex_home() {
+        return path;
+    }
+    engine_home(Some("CODEX_HOME"), ".codex")
+}
+
+#[cfg(not(test))]
+fn settings_codex_home() -> Option<PathBuf> {
+    let custom = crate::settings::read_settings().ok()?.codex_home?;
+    let trimmed = custom.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    crate::open_app::expand_user_path(trimmed).ok()
+}
+
 /// Home dir for the default engine path. Production uses `dirs` (Known
 /// Folder API on Windows); tests steer the fallback through HOME /
 /// USERPROFILE env instead, because `dirs` ignores env on Windows and would
@@ -814,7 +836,22 @@ pub struct EngineInfo {
     pub permissions: Vec<String>,
 }
 
+fn codex_bin_from_home(settings: &crate::settings::AppSettings) -> Option<String> {
+    let home = settings.codex_home.as_deref()?.trim();
+    if home.is_empty() {
+        return None;
+    }
+    let expanded = crate::open_app::expand_user_path(home).ok()?;
+    let candidate = expanded.join("bin").join("codex");
+    candidate.exists().then(|| resolve::resolve_launchable_cli_binary(&candidate.to_string_lossy()))
+}
+
 pub(crate) fn engine_bin(settings: &crate::settings::AppSettings, engine_id: &str) -> String {
+    if engine_id == "codex" {
+        if let Some(from_home) = codex_bin_from_home(settings) {
+            return from_home;
+        }
+    }
     if let Some(custom) = settings.bin_override(engine_id) {
         let trimmed = custom.trim();
         if !trimmed.is_empty() {
@@ -843,6 +880,7 @@ pub fn list_engines() -> Vec<EngineInfo> {
                 Some(custom) if !custom.trim().is_empty() => {
                     crate::settings::validate_bin_override(custom).is_ok()
                 }
+                _ if *id == "codex" && codex_bin_from_home(&settings).is_some() => true,
                 _ => resolve::find_cli_binary(id, None).is_some(),
             };
             EngineInfo {
@@ -2119,5 +2157,31 @@ mod tool_args_tests {
             EngineEvent::Message { patch, .. } => assert!(patch),
             _ => panic!("expected patch"),
         }
+    }
+}
+
+#[cfg(test)]
+mod codex_home_bin_tests {
+    use super::*;
+
+    #[test]
+    fn engine_bin_prefers_codex_home_bin() {
+        let dir = std::env::temp_dir().join(format!(
+            "ccgui-codex-home-bin-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(dir.join("bin")).unwrap();
+        let candidate = dir.join("bin").join("codex");
+        std::fs::write(&candidate, "#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&candidate, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let mut settings = crate::settings::AppSettings::default();
+        settings.codex_home = Some(dir.to_string_lossy().into_owned());
+        let resolved = engine_bin(&settings, "codex");
+        assert_eq!(PathBuf::from(&resolved), candidate);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/engine/models/codex.rs
+++ b/src-tauri/src/engine/models/codex.rs
@@ -4,7 +4,7 @@ use super::{parse_top_level_toml_string, run_probe, EngineModel};
 /// (default ~/.codex), the same file `codex exec` reads — provider channels are written there on switch
 /// (provider_files), so this reflects the active channel.
 pub(super) fn codex_config_model() -> Option<EngineModel> {
-    let home = crate::engine::engine_home(Some("CODEX_HOME"), ".codex");
+    let home = crate::engine::codex_home();
     let content = std::fs::read_to_string(home.join("config.toml")).ok()?;
     let model = parse_top_level_toml_string(&content, "model")?;
     Some(EngineModel {

--- a/src-tauri/src/engine/resolve.rs
+++ b/src-tauri/src/engine/resolve.rs
@@ -137,6 +137,7 @@ fn build_windows_extra_search_paths(
         // Fallback: npm global install path via USERPROFILE.
         paths.push(user_profile.join("AppData\\Roaming\\npm"));
         paths.push(user_profile.join(".local\\bin"));
+        paths.push(user_profile.join(".codex-cli\\bin"));
         paths.push(user_profile.join(".local\\share\\mise\\shims"));
         // Hermes ships dsh as a Node-global bin, same layout as ~/.hermes/node/bin.
         paths.push(user_profile.join(".hermes\\node"));
@@ -232,6 +233,7 @@ fn build_unix_extra_search_paths() -> Vec<PathBuf> {
     ];
     if let Some(home) = dirs::home_dir() {
         paths.push(home.join(".local/bin"));
+        paths.push(home.join(".codex-cli/bin"));
         paths.push(home.join(".local/share/mise/shims"));
         paths.push(home.join(".cargo/bin"));
         paths.push(home.join(".bun/bin"));
@@ -262,6 +264,12 @@ fn get_extra_search_paths() -> Vec<PathBuf> {
     #[cfg(not(windows))]
     {
         paths.extend(build_unix_extra_search_paths());
+    }
+
+    if let Ok(codex_home) = std::env::var("CODEX_HOME") {
+        if !codex_home.trim().is_empty() {
+            push_unique_path(&mut paths, PathBuf::from(codex_home.trim()).join("bin"));
+        }
     }
 
     for prefix_key in ["NPM_CONFIG_PREFIX", "npm_config_prefix"] {

--- a/src-tauri/src/history/codex_titles.rs
+++ b/src-tauri/src/history/codex_titles.rs
@@ -31,7 +31,7 @@ fn read_names(path: &Path) -> HashMap<String, String> {
 /// modify its rollout. Update the derived title, leaving local custom titles
 /// and message timestamps intact.
 pub(super) fn sync(db: &crate::db::Db) -> Result<bool, String> {
-    let home = crate::engine::engine_home(Some("CODEX_HOME"), ".codex");
+    let home = crate::engine::codex_home();
     sync_from(db, &home.join("session_index.jsonl"))
 }
 

--- a/src-tauri/src/history/scanner.rs
+++ b/src-tauri/src/history/scanner.rs
@@ -339,7 +339,7 @@ fn identify_head(engine: &str, path: &Path) -> Option<(String, String)> {
 
 /// Codex rollout files (readdir only, no content reads).
 fn codex_candidates() -> Vec<PathBuf> {
-    let home = crate::engine::engine_home(Some("CODEX_HOME"), ".codex");
+    let home = crate::engine::codex_home();
     let mut out = Vec::new();
     for root in [home.join("sessions"), home.join("archived_sessions")] {
         let mut stack = vec![root];
@@ -476,6 +476,9 @@ fn gather_candidates(workspaces: &[String]) -> Vec<Candidate> {
 fn stat_all(workspaces: &[String], candidates: &[Candidate]) -> (Vec<Option<(i64, i64)>>, String) {
     let mut signature_hasher = Sha256::new();
     signature_hasher.update(format!("v{}|", crate::db::CACHE_VERSION).as_bytes());
+    signature_hasher.update(b"codex_home=");
+    signature_hasher.update(crate::engine::codex_home().to_string_lossy().as_bytes());
+    signature_hasher.update(b"|");
     for w in workspaces {
         signature_hasher.update(w.as_bytes());
         signature_hasher.update(b"|");
@@ -693,6 +696,77 @@ fn prune_codex_subagent_sessions(db: &crate::db::Db) -> Result<bool, String> {
     Ok(true)
 }
 
+fn path_is_under(path: &str, home: &Path) -> bool {
+    let path = Path::new(path);
+    if path.starts_with(home) {
+        return true;
+    }
+    match (std::fs::canonicalize(path), std::fs::canonicalize(home)) {
+        (Ok(path), Ok(home)) => path.starts_with(home),
+        _ => false,
+    }
+}
+
+/// Drop Codex rows indexed from a previous CODEX_HOME after the user points
+/// CLI 管理 at another directory. Returns true when any row was removed.
+///
+/// No custom home → no-op. Default `~/.codex` users must not lose history
+/// because of a path-prefix mismatch (symlink, case, missing file).
+fn prune_codex_sessions_outside_home(db: &crate::db::Db) -> Result<bool, String> {
+    #[cfg(not(test))]
+    {
+        let custom = crate::settings::read_settings()
+            .ok()
+            .and_then(|s| s.codex_home)
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        if custom.is_none() {
+            return Ok(false);
+        }
+    }
+    let home = crate::engine::codex_home();
+    let paths: Vec<(String, String)> = {
+        let conn = db.0.lock();
+        let mut stmt = conn
+            .prepare("SELECT session_id, file_path FROM sessions WHERE engine='codex'")
+            .map_err(|e| e.to_string())?;
+        let rows = stmt
+            .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))
+            .map_err(|e| e.to_string())?;
+        let mut out = Vec::new();
+        for row in rows {
+            match row {
+                Ok(pair) => out.push(pair),
+                Err(e) => eprintln!("[scanner] skipping undecodable codex session row: {e}"),
+            }
+        }
+        out
+    };
+    let dead: Vec<String> = paths
+        .into_iter()
+        .filter(|(_, path)| !path_is_under(path, &home))
+        .map(|(id, _)| id)
+        .collect();
+    if dead.is_empty() {
+        return Ok(false);
+    }
+    let conn = db.0.lock();
+    for id in &dead {
+        conn.execute(
+            "DELETE FROM sessions WHERE engine='codex' AND session_id=?1",
+            rusqlite::params![id],
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    Ok(true)
+}
+
+fn prune_stale_codex_sessions(db: &crate::db::Db) -> Result<bool, String> {
+    let outside = prune_codex_sessions_outside_home(db)?;
+    let subagent = prune_codex_subagent_sessions(db)?;
+    Ok(outside || subagent)
+}
+
 /// Phase B (one lock, one transaction): upsert every prepared row, then
 /// record the signature that makes the next scan a short-circuit.
 fn upsert_rows(db: &crate::db::Db, rows: &[PreparedUpsert], tier1: &Tier1) -> Result<(), String> {
@@ -759,7 +833,7 @@ fn scan_inner(
     let candidates = gather_candidates(&workspaces);
     let (stats, signature) = stat_all(&workspaces, &candidates);
     let Some(tier1) = tier1_gate(db, signature)? else {
-        let pruned = prune_codex_subagent_sessions(db)?;
+        let pruned = prune_stale_codex_sessions(db)?;
         if super::codex_titles::sync(db)? || pruned {
             on_changed();
         }
@@ -808,7 +882,7 @@ fn scan_inner(
     // Phase B: the db lock is held only for the upsert transaction.
     let reparsed = rows.len();
     upsert_rows(db, &rows, &tier1)?;
-    prune_codex_subagent_sessions(db)?;
+    prune_stale_codex_sessions(db)?;
     super::codex_titles::sync(db)?;
     on_changed();
     if total > 0 {
@@ -1296,6 +1370,86 @@ mod tests {
                 .map_err(|e| e.to_string())?
         };
         assert_eq!(ids, vec!["parent".to_string()]);
+        drop(db);
+        std::fs::remove_dir_all(&home).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn default_codex_home_keeps_indexed_sessions() -> Result<(), String> {
+        let home = scratch_dir("scan-codex-default-keep");
+        let workspace = home.join("ws");
+        std::fs::create_dir_all(&workspace).map_err(|e| e.to_string())?;
+        let rollout = home
+            .join(".codex")
+            .join("sessions")
+            .join("rollout-keep.jsonl");
+        std::fs::create_dir_all(rollout.parent().unwrap()).map_err(|e| e.to_string())?;
+        let _guard = HomeGuard::set(&home);
+        let db = crate::db::Db::open_at(&home.join("app.db")).map_err(|e| e.to_string())?;
+        {
+            let conn = db.0.lock();
+            conn.execute(
+                "INSERT INTO workspaces(id, path, name) VALUES('w1', ?1, 'ws')",
+                [workspace.to_string_lossy().to_string()],
+            )
+            .map_err(|e| e.to_string())?;
+            conn.execute(
+                "INSERT INTO sessions(engine, session_id, workspace_path, file_path, file_size, file_mtime_ms, title) VALUES('codex', 'keep', ?1, ?2, 1, 1, '默认目录')",
+                rusqlite::params![
+                    workspace.to_string_lossy().to_string(),
+                    rollout.to_string_lossy().to_string()
+                ],
+            )
+            .map_err(|e| e.to_string())?;
+        }
+        scan_with(&db, || {})?;
+        let count: i64 = {
+            let conn = db.0.lock();
+            conn.query_row(
+                "SELECT COUNT(*) FROM sessions WHERE engine='codex' AND session_id='keep'",
+                [],
+                |r| r.get(0),
+            )
+            .map_err(|e| e.to_string())?
+        };
+        assert_eq!(count, 1);
+        drop(db);
+        std::fs::remove_dir_all(&home).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn scan_prunes_codex_rows_from_another_home() -> Result<(), String> {
+        let home = scratch_dir("scan-codex-wrong-home");
+        let workspace = home.join("ws");
+        std::fs::create_dir_all(&workspace).map_err(|e| e.to_string())?;
+        let _guard = HomeGuard::set(&home);
+        let db = crate::db::Db::open_at(&home.join("app.db")).map_err(|e| e.to_string())?;
+        {
+            let conn = db.0.lock();
+            conn.execute(
+                "INSERT INTO workspaces(id, path, name) VALUES('w1', ?1, 'ws')",
+                [workspace.to_string_lossy().to_string()],
+            )
+            .map_err(|e| e.to_string())?;
+            conn.execute(
+                "INSERT INTO sessions(engine, session_id, workspace_path, file_path, file_size, file_mtime_ms, title) VALUES('codex', 'old', ?1, '/Users/demo/.codex/sessions/old.jsonl', 1, 1, '旧目录')",
+                [workspace.to_string_lossy().to_string()],
+            )
+            .map_err(|e| e.to_string())?;
+        }
+        scan_with(&db, || {})?;
+        let count: i64 = {
+            let conn = db.0.lock();
+            conn.query_row(
+                "SELECT COUNT(*) FROM sessions WHERE engine='codex'",
+                [],
+                |r| r.get(0),
+            )
+            .map_err(|e| e.to_string())?
+        };
+        assert_eq!(count, 0);
         drop(db);
         std::fs::remove_dir_all(&home).ok();
         Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,6 +56,7 @@ pub fn run() {
         if let Err(error) = proxy::apply_app_proxy_settings(&settings) {
             eprintln!("[proxy] failed to apply persisted proxy settings: {error}");
         }
+        settings::apply_codex_home(&settings);
     }
 
     tauri::Builder::default()

--- a/src-tauri/src/provider_files.rs
+++ b/src-tauri/src/provider_files.rs
@@ -75,7 +75,7 @@ fn targets(engine: &str) -> Vec<Target> {
             "settings.json",
         )],
         "codex" => {
-            let home = home(Some("CODEX_HOME"), ".codex");
+            let home = crate::engine::codex_home();
             vec![
                 target(home.join("config.toml"), "config.toml"),
                 target(home.join("auth.json"), "auth.json"),

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -52,6 +52,10 @@ pub struct AppSettings {
     /// Per-app Codex Fast override (`service_tier`); None preserves ~/.codex.
     #[serde(default)]
     pub codex_service_tier: Option<String>,
+    /// Codex config/session home (`CODEX_HOME`). None keeps ~/.codex, or a
+    /// CODEX_HOME already present in the process environment at launch.
+    #[serde(default)]
+    pub codex_home: Option<String>,
     /// Require a pairing key before the bridge serves a browser (设置 → 远程
     /// 访问 → 启用授权). Off by default: on the LAN the token URL is enough.
     #[serde(default)]
@@ -144,6 +148,7 @@ impl Default for AppSettings {
             default_efforts: HashMap::new(),
             omp_openai_service_tier: None,
             codex_service_tier: None,
+            codex_home: None,
             sidebar_thread_limit: default_sidebar_thread_limit(),
             composer_send_shortcut: default_composer_send_shortcut(),
             terminal_shell_path: None,
@@ -179,21 +184,70 @@ pub(crate) fn validate_bin_override(value: &str) -> Result<std::path::PathBuf, S
     }
     let canonical = std::fs::canonicalize(&path)
         .map_err(|e| format!("{}: cannot resolve ({e})", path.display()))?;
-    const TEMP_ROOTS: &[&str] = &[
-        "/tmp",
-        "/var/folders",
-        "/private/tmp",
-        "/private/var/folders",
-    ];
+    reject_temp_root(&canonical, "binaries")?;
+    Ok(canonical)
+}
+
+const TEMP_ROOTS: &[&str] = &[
+    "/tmp",
+    "/var/folders",
+    "/private/tmp",
+    "/private/var/folders",
+];
+
+fn reject_temp_root(path: &std::path::Path, kind: &str) -> Result<(), String> {
     for root in TEMP_ROOTS {
-        if canonical.starts_with(root) {
+        if path.starts_with(root) {
             return Err(format!(
-                "{}: binaries under {root} are not allowed",
-                canonical.display()
+                "{}: {kind} under {root} are not allowed",
+                path.display()
             ));
         }
     }
-    Ok(canonical)
+    Ok(())
+}
+
+/// Codex home override: absolute directory (may not exist yet). `~` is
+/// expanded. Same temp-dir refusal as bin overrides.
+fn validate_home_override(value: &str) -> Result<std::path::PathBuf, String> {
+    let expanded = crate::open_app::expand_user_path(value.trim())?;
+    if !expanded.is_absolute() {
+        return Err(format!("{}: not an absolute path", expanded.display()));
+    }
+    if expanded.exists() && !expanded.is_dir() {
+        return Err(format!("{}: not a directory", expanded.display()));
+    }
+    let check = if expanded.exists() {
+        std::fs::canonicalize(&expanded).unwrap_or_else(|_| expanded.clone())
+    } else {
+        expanded.clone()
+    };
+    reject_temp_root(&check, "homes")?;
+    Ok(expanded)
+}
+
+/// Push `settings.codex_home` into this process's `CODEX_HOME` so every
+/// existing `engine_home(Some("CODEX_HOME"), ".codex")` call site — official
+/// config, history, skills, catalog probes, and spawned `codex` — sees the
+/// same directory. Clearing the setting only unsets an env we previously
+/// applied, so a launch-time `CODEX_HOME` survives.
+pub(crate) fn apply_codex_home(settings: &AppSettings) {
+    static APPLIED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+    if let Some(home) = settings
+        .codex_home
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        if let Ok(expanded) = validate_home_override(home) {
+            std::env::set_var("CODEX_HOME", expanded);
+            APPLIED.store(true, std::sync::atomic::Ordering::Relaxed);
+            return;
+        }
+    }
+    if APPLIED.swap(false, std::sync::atomic::Ordering::Relaxed) {
+        std::env::remove_var("CODEX_HOME");
+    }
 }
 
 pub fn read_settings() -> Result<AppSettings, String> {
@@ -418,10 +472,20 @@ pub fn update_app_settings<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
     mut settings: AppSettings,
 ) -> Result<(), String> {
+    let prev_home = read_settings().ok().and_then(|s| s.codex_home);
     let result = persist_settings(&mut settings);
     // Other surfaces (the composer's proxy toggle) follow along without
     // re-reading settings.json.
     let _ = app.emit("settings://changed", ());
+    if result.is_ok() && prev_home != settings.codex_home {
+        use tauri::Manager;
+        if let Some(state) = app.try_state::<crate::AppState>() {
+            crate::history::scanner::spawn_scan(
+                std::sync::Arc::clone(&state.db),
+                std::sync::Arc::clone(&state.sink),
+            );
+        }
+    }
     result
 }
 
@@ -477,6 +541,15 @@ pub fn persist_settings(settings: &mut AppSettings) -> Result<(), String> {
             }
         }
     }
+    if let Some(home) = settings.codex_home.take() {
+        let trimmed = home.trim().to_string();
+        if !trimmed.is_empty() {
+            match validate_home_override(&trimmed) {
+                Ok(path) => settings.codex_home = Some(path.to_string_lossy().into_owned()),
+                Err(reason) => rejected.push(format!("codexHome: {reason}")),
+            }
+        }
+    }
     let path = crate::paths::settings_path();
     let content = serde_json::to_string_pretty(&settings).map_err(|e| e.to_string())?;
     // Reject before persisting: an invalid proxy URL must not be saved (the
@@ -485,6 +558,7 @@ pub fn persist_settings(settings: &mut AppSettings) -> Result<(), String> {
     atomic_write(&path, &content)?;
     // Apply to this process's env so the next spawned child inherits it.
     crate::proxy::apply_app_proxy_settings(&settings)?;
+    apply_codex_home(settings);
     if rejected.is_empty() {
         Ok(())
     } else {
@@ -756,6 +830,15 @@ mod tests {
         assert!(!pairing_key_matches("", "--------"));
         assert!(!pairing_key_matches("", ""));
         assert!(!pairing_key_matches("BCDF2345", "BCDF2346"));
+    }
+
+    #[test]
+    fn home_override_expands_tilde_and_rejects_temp() {
+        let home = validate_home_override("~/.codex-cli").unwrap();
+        assert!(home.is_absolute());
+        assert!(home.ends_with(".codex-cli"));
+        assert!(validate_home_override("/tmp/codex-home").is_err());
+        assert!(validate_home_override("relative/codex").is_err());
     }
 
     /// The property the relay's whole gate rests on: a code opens exactly one

--- a/src-tauri/src/slash_commands.rs
+++ b/src-tauri/src/slash_commands.rs
@@ -246,7 +246,7 @@ fn skills_dirs(workspace_root: &Path) -> Vec<(PathBuf, &'static str)> {
     if claude_global.is_dir() {
         dirs.push((claude_global, "global"));
     }
-    let codex_home = crate::engine::engine_home(Some("CODEX_HOME"), ".codex");
+    let codex_home = crate::engine::codex_home();
     let codex_skills = codex_home.join("skills");
     // `.system` holds Codex's built-in skills one level deeper than the
     // personal ones; both are global scope.

--- a/src/features/settings/CliConfigBody.test.tsx
+++ b/src/features/settings/CliConfigBody.test.tsx
@@ -13,6 +13,7 @@ vi.mock("./PiFamilyAuthSection", () => ({
   PiFamilyAuthSection: () => <div data-testid="pi-auth-section" />,
 }));
 
+import { CLI_DISPLAY_NAMES } from "@/components/foundations/icons/engine-brands";
 import i18n from "@/lib/i18n";
 import { CliConfigBody } from "./CliConfigBody";
 import type { CliConfigState } from "./useCliConfig";
@@ -164,5 +165,20 @@ describe("CliEngineSettingsCard official edit entry", () => {
   it("dsh: no official config row at all (no native config file)", async () => {
     await render(makeCli({ engine: "dsh" }));
     expect(container.textContent).not.toContain(i18n.t("settings.cliOfficial"));
+  });
+
+  it("codex: one path row (config home), not a separate binary override", async () => {
+    await render(makeCli({ engine: "codex" }));
+    expect(container.textContent).toContain(
+      i18n.t("settings.cliCustomHome", { name: CLI_DISPLAY_NAMES.codex }),
+    );
+    expect(container.textContent).not.toContain(i18n.t("settings.cliCustomPathUnset"));
+  });
+
+  it("claude: does not show a Codex config-home row", async () => {
+    await render(makeCli({ engine: "claude" }));
+    expect(container.textContent).not.toContain(
+      i18n.t("settings.cliCustomHome", { name: CLI_DISPLAY_NAMES.codex }),
+    );
   });
 });

--- a/src/features/settings/CliEngineSettingsCard.tsx
+++ b/src/features/settings/CliEngineSettingsCard.tsx
@@ -6,7 +6,11 @@
  *     being active; pi/omp hand off to their models.json/models.yml editor;
  *     dsh has no native config file and hides the row).
  *   自定义 CLI 路径 — AppSettings.<engine>Bin override (dsh keeps its own
- *     picker inside DshHostSection and hides the row here).
+ *     picker inside DshHostSection and hides the row here). Codex hides
+ *     this row: its one path control is the config-home row below, which
+ *     also seeds `$home/bin/codex`.
+ *   自定义配置目录 — AppSettings.codexHome (Codex only; other engines keep
+ *     their implicit ~/.<engine> homes).
  *   自定义模型 — AppSettings.customModels[engine] list, merged into the chat
  *     model picker by use-engine-models.
  *
@@ -27,7 +31,7 @@ import { SettingsCard } from "@/components/application/settings/settings-rows";
 import { ModalShell } from "@/components/dialogs";
 import { CLI_DISPLAY_NAMES } from "@/components/foundations/icons/engine-brands";
 import { ipc, type AppSettings } from "@/lib/ipc";
-import { pickFile } from "@/lib/platform";
+import { pickDirectory, pickFile } from "@/lib/platform";
 import { cx } from "@/utils/cx";
 import { Badge, ChannelAvatar, ROW } from "./CliChannelRow";
 import { notifyCliConfigChanged, PSEUDO_LOCAL, type EngineId } from "./providers";
@@ -297,6 +301,117 @@ function BinPathDialog({
   );
 }
 
+// ── 自定义 Codex 配置目录 ───────────────────────────────────────────────────
+
+function CodexHomeRow() {
+  const { t } = useTranslation();
+  const { settings, save } = useEngineAppSettings();
+  const [open, setOpen] = useState(false);
+  const current = settings?.codexHome ?? null;
+  return (
+    <>
+      <RowShell
+        title={
+          <>
+            <span className="truncate">{t("settings.cliCustomHome", { name: CLI_DISPLAY_NAMES.codex })}</span>
+            <InfoTip label={t("settings.cliCustomHomeDesc")} />
+          </>
+        }
+        desc={current ?? t("settings.cliCustomHomeUnset")}
+        onClick={() => setOpen(true)}
+      >
+        <RowChevron label={t("settings.cliCustomHome", { name: CLI_DISPLAY_NAMES.codex })} />
+      </RowShell>
+      {open && (
+        <CodexHomeDialog current={current} save={save} onClose={() => setOpen(false)} />
+      )}
+    </>
+  );
+}
+
+function CodexHomeDialog({
+  current,
+  save,
+  onClose,
+}: {
+  current: string | null;
+  save: (patch: Partial<AppSettings>) => Promise<string | null>;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation();
+  const [draft, setDraft] = useState(current ?? "");
+  const [error, setError] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const commit = async (value: string | null) => {
+    setSaving(true);
+    try {
+      const failed = await save({ codexHome: value });
+      if (failed) setError(failed);
+      else {
+        notifyCliConfigChanged();
+        void ipc.rescanSessions().catch(() => {});
+        onClose();
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <ModalShell onClose={onClose} className="w-[480px] max-w-[calc(100vw-32px)] p-6">
+      <p className="text-title-3-medium text-text-primary">
+        {t("settings.cliCustomHome", { name: CLI_DISPLAY_NAMES.codex })}
+      </p>
+      <p className="mt-1.5 text-body-2-regular text-text-secondary">
+        {t("settings.cliCustomHomeDesc")}
+      </p>
+      <div className="mt-5 flex items-end gap-2">
+        <div className="min-w-0 flex-1">
+          <Input
+            size="small"
+            aria-label={t("settings.cliCustomHome", { name: CLI_DISPLAY_NAMES.codex })}
+            placeholder={t("settings.cliCustomHomeUnset")}
+            value={draft}
+            onChange={setDraft}
+          />
+        </div>
+        <Button
+          variant="secondary"
+          size="small"
+          onClick={() =>
+            void pickDirectory(t("settings.cliCustomHome", { name: CLI_DISPLAY_NAMES.codex })).then(
+              (path) => {
+                if (path) setDraft(path);
+              },
+            )
+          }
+        >
+          {t("settings.cliCustomHomeChoose")}
+        </Button>
+      </div>
+      {error && <p className="mt-2 text-body-2-regular text-text-error-primary">{error}</p>}
+      <div className="mt-5 flex justify-end gap-2">
+        {current && (
+          <Button variant="secondary" size="small" disabled={saving} onClick={() => void commit(null)}>
+            {t("settings.cliCustomPathClear")}
+          </Button>
+        )}
+        <Button variant="secondary" size="small" onClick={onClose}>
+          {t("common.cancel")}
+        </Button>
+        <Button
+          size="small"
+          disabled={saving || !draft.trim() || draft.trim() === (current ?? "")}
+          onClick={() => void commit(draft.trim())}
+        >
+          {t("common.confirm")}
+        </Button>
+      </div>
+    </ModalShell>
+  );
+}
+
 // ── 自定义模型 ──────────────────────────────────────────────────────────────
 
 function CustomModelsRow({ engine }: { engine: EngineId }) {
@@ -462,7 +577,8 @@ export function CliEngineSettingsCard({
   return (
     <SettingsCard>
       {engine !== "dsh" && <OfficialRow cli={cli} onEdit={onEditOfficial} />}
-      {engine !== "dsh" && <BinPathRow engine={engine as BinEngine} />}
+      {engine !== "dsh" && engine !== "codex" && <BinPathRow engine={engine as BinEngine} />}
+      {engine === "codex" && <CodexHomeRow />}
       <CustomModelsRow engine={engine} />
     </SettingsCard>
   );

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -429,6 +429,11 @@ export const en: Messages = {
     cliCustomPathUnset: "Auto-detect",
     cliCustomPathChoose: "Choose file",
     cliCustomPathClear: "Clear",
+    cliCustomHome: "Custom {{name}} path",
+    cliCustomHomeDesc:
+      "Official config, session history, and skills read this directory; the binary prefers bin/codex inside it. Leave empty to use ~/.codex and auto-detect the binary.",
+    cliCustomHomeUnset: "~/.codex (default)",
+    cliCustomHomeChoose: "Choose folder",
     cliCustomModels: "Custom models",
     cliCustomModelsDesc: "Add custom models for this CLI",
     cliCustomModelsDialogDesc: "Added models appear in this CLI's model picker.",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -409,6 +409,11 @@ export const zh = {
     cliCustomPathUnset: "自动检测",
     cliCustomPathChoose: "选择文件",
     cliCustomPathClear: "清除",
+    cliCustomHome: "自定义 {{name}} 路径",
+    cliCustomHomeDesc:
+      "官方配置、会话历史和技能都读这个目录；可执行文件优先用其中的 bin/codex。留空则使用 ~/.codex 并自动检测二进制。",
+    cliCustomHomeUnset: "~/.codex（默认）",
+    cliCustomHomeChoose: "选择目录",
     cliCustomModels: "自定义模型",
     cliCustomModelsDesc: "在此CLI添加自定义模型",
     cliCustomModelsDialogDesc: "添加的模型会出现在该 CLI 的模型选择列表中。",

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -195,6 +195,8 @@ export interface AppSettings {
   ompOpenaiServiceTier?: "default" | "priority" | null;
   /** Codex Fast override; null preserves ~/.codex/config.toml. */
   codexServiceTier?: "default" | "priority" | null;
+  /** Codex config/session home (`CODEX_HOME`); null uses ~/.codex. */
+  codexHome?: string | null;
   /** Max sessions listed per workspace in the sidebar (default 5). */
   sidebarThreadLimit: number;
   /** Composer send gesture: "enter" (Enter sends) or "cmdEnter" (⌘/Ctrl+Enter sends). */


### PR DESCRIPTION
## Summary
- CLI 管理为 Codex 增加单一路径（`CODEX_HOME`），官方配置、会话历史和技能都读这个目录；可执行文件优先用其中的 `bin/codex`，留空仍走 `~/.codex`。
- 改目录后自动重扫历史，并只在设置了自定义目录时清理旧 home 的会话，避免默认用户被误删。
- 非 npm 安装的 Codex 一键更新改为官方 `install.sh`，不再强制 `npm i -g`。

## Test plan
- [ ] 不设自定义路径：历史仍来自 `~/.codex`，官方配置和自动检测二进制与改前一致
- [ ] 设为 `~/.codex-cli`：官方配置、侧栏历史、技能都切到新目录；旧 `~/.codex` 会话从列表消失
- [ ] 清掉自定义路径：回到 `~/.codex`，默认会话还在
- [ ] Codex 设置页只有一行路径，没有单独的二进制覆盖行
- [ ] standalone Codex 的一键更新预览是官方安装脚本，npm 安装的 Codex 仍走 npm